### PR TITLE
Fix: Filter by Strategy doesn't show the Vaults in results

### DIFF
--- a/src/components/common/VaultsList/index.tsx
+++ b/src/components/common/VaultsList/index.tsx
@@ -41,12 +41,14 @@ export const VaultsList = (props: VaultsListProps) => {
             const filteredItems = props.items.filter((item: Vault) => {
                 const filteredStrategies = filterStrategies(item, newText);
                 totalStrategiesFound += filteredStrategies.length;
+                const hasVaultStrategies = filteredStrategies.length > 0;
                 return (
                     item.address.toLowerCase().includes(newText) ||
                     item.apiVersion.includes(newText) ||
                     item.name.toLowerCase().includes(newText) ||
                     item.symbol.toLowerCase().includes(newText) ||
-                    item.token.symbol.toLowerCase().includes(newText)
+                    item.token.symbol.toLowerCase().includes(newText) ||
+                    hasVaultStrategies
                 );
             });
             setFilteredItems(filteredItems);


### PR DESCRIPTION
It includes:

- Fix to show the vaults when user filters by strategy fields.


![image](https://user-images.githubusercontent.com/5948309/120527028-197c8100-c397-11eb-949e-2e6a4f0fe188.png)

![image](https://user-images.githubusercontent.com/5948309/120527079-2a2cf700-c397-11eb-9ff4-6752d987068d.png)
