### PR TITLE
Add Warnings to Main Vaults Page

### DIFF
--- a/src/components/app/VaultItemList/index.tsx
+++ b/src/components/app/VaultItemList/index.tsx
@@ -1,3 +1,4 @@
+import { Fragment } from 'react';
 import { Theme, createStyles, makeStyles } from '@material-ui/core/styles';
 import Container from '@material-ui/core/Container';
 import MuiAccordion from '@material-ui/core/Accordion';
@@ -13,6 +14,10 @@ import EtherScanLink from '../../common/EtherScanLink';
 
 import Grid from '@material-ui/core/Grid';
 import Hidden from '@material-ui/core/Hidden';
+import { ReportProblem } from '@material-ui/icons';
+import { Typography } from '@material-ui/core';
+import { HtmlTooltip } from '../../common/HtmlTooltip';
+
 type VaultItemListProps = {
     vault: Vault;
     key: number;
@@ -44,7 +49,11 @@ export const VaultItemList = (props: VaultItemListProps) => {
                     fontSize: 19,
                 },
             },
-
+            warningIcon: {
+                borderRadius: 3,
+                padding: 1,
+                boxShadow: '0px 0px 0px 0 rgba(0,0,0,0.2)',
+            },
             expandIcon: {
                 color: '#fff',
             },
@@ -123,6 +132,35 @@ export const VaultItemList = (props: VaultItemListProps) => {
                                     )}
                                 </Grid>
                                 <Grid item md={5} xs={9}>
+                                    {vault.configErrors ? (
+                                        <HtmlTooltip
+                                            title={
+                                                <Fragment>
+                                                    <Typography color="inherit">
+                                                        {
+                                                            vault.configErrors
+                                                                .length
+                                                        }{' '}
+                                                        warning(s) found
+                                                    </Typography>
+                                                    {vault.configErrors.map(
+                                                        (error, index) => (
+                                                            <em key={index}>
+                                                                {error}
+                                                                <br />
+                                                            </em>
+                                                        )
+                                                    )}
+                                                </Fragment>
+                                            }
+                                        >
+                                            <ReportProblem
+                                                className={classes.warningIcon}
+                                            />
+                                        </HtmlTooltip>
+                                    ) : (
+                                        ''
+                                    )}
                                     <a
                                         className={classes.link}
                                         href={`/vault/${vault.address}`}

--- a/src/components/common/HtmlTooltip/index.ts
+++ b/src/components/common/HtmlTooltip/index.ts
@@ -1,0 +1,12 @@
+import { withStyles } from '@material-ui/core/styles';
+import { Tooltip } from '@material-ui/core';
+
+export const HtmlTooltip = withStyles((theme) => ({
+    tooltip: {
+        backgroundColor: '#f5f5f9',
+        color: 'rgba(0, 0, 0, 0.87)',
+        maxWidth: 220,
+        fontSize: theme.typography.pxToRem(12),
+        border: '1px solid #dadde9',
+    },
+}))(Tooltip);


### PR DESCRIPTION
It includes:

- Warnings on the main vault page.

![image](https://user-images.githubusercontent.com/5948309/121240677-995b8d00-c868-11eb-8e54-394085738f7c.png)
