### PR TITLE
Fix Strategy Page.

### DIFF
--- a/src/components/app/SingleStrategy/AccordionReport.tsx
+++ b/src/components/app/SingleStrategy/AccordionReport.tsx
@@ -50,7 +50,7 @@ const AccordionReport = (props: AccordionReportProps) => {
     const { data, tokenDecimals } = props;
     const classes = useStyles();
 
-    const aprList = data.map((item) => item.results.apr);
+    const aprList = data.map((item) => item.results?.apr);
     const averageApr =
         aprList.length === 0 ? 0 : _.sum(aprList) / aprList.length;
     const averageAprLabel = `Average APR: ${averageApr.toFixed(2)}%`;
@@ -167,8 +167,11 @@ const AccordionReport = (props: AccordionReportProps) => {
                                     <ItemDescription
                                         label="Duration (hours)"
                                         value={msToHours(
-                                            res.results.duration
+                                            res.results
+                                                ? res.results.duration
+                                                : 0
                                         ).toFixed(2)}
+                                        visible={res.results !== undefined}
                                         md={3}
                                         helpTitle="What is it?"
                                         helpDescription={
@@ -181,9 +184,10 @@ const AccordionReport = (props: AccordionReportProps) => {
                                     />
                                     <ItemDescription
                                         label="Duration PR"
-                                        value={`${res.results.durationPr.toFixed(
+                                        value={`${res.results?.durationPr.toFixed(
                                             6
                                         )} %`}
+                                        visible={res.results !== undefined}
                                         md={3}
                                         helpTitle="What is the duration PR?"
                                         helpDescription={
@@ -205,9 +209,10 @@ const AccordionReport = (props: AccordionReportProps) => {
                                     />
                                     <ItemDescription
                                         label="APR"
-                                        value={`${res.results.apr.toFixed(
+                                        value={`${res.results?.apr.toFixed(
                                             2
                                         )} %`}
+                                        visible={res.results !== undefined}
                                         md={3}
                                         helpTitle="How is APR calculated?"
                                         helpDescription={

--- a/src/components/common/ItemDescription/index.tsx
+++ b/src/components/common/ItemDescription/index.tsx
@@ -20,13 +20,17 @@ type ItemDescriptionProps = {
     value: number | string;
     xs?: boolean | GridSize | undefined;
     md: boolean | GridSize | undefined;
+    visible?: boolean;
     helpTitle?: string;
     helpDescription?: ReactNode;
 };
 
 const ItemDescription = (props: ItemDescriptionProps) => {
-    const { xs = 12 } = props;
+    const { xs = 12, visible = true } = props;
     const classes = useStyles();
+    if (!visible) {
+        return <></>;
+    }
 
     const helpTooltip =
         props.helpTitle && props.helpDescription ? (

--- a/src/utils/reports.ts
+++ b/src/utils/reports.ts
@@ -119,7 +119,7 @@ export type StrategyReport = {
     totalProfit: string;
     totalLoss: string;
     transactionHash: string;
-    results: {
+    results?: {
         startTimestamp: number;
         endTimestamp: number;
         duration: number;
@@ -172,14 +172,10 @@ const _getReportsForStrategy = async (
 
     const OMIT_FIELDS = ['results', 'transaction', 'id'];
     const values = reports.map((report) => {
-        const result = report.results[0];
-        return {
-            ...(omit(report, OMIT_FIELDS) as StratReportGraphType),
-            profit: report.gain,
-            loss: report.loss,
-            totalProfit: report.totalGain,
-            transactionHash: report.transaction.hash,
-            results: {
+        let results;
+        if (report.results.length > 0) {
+            const result = report.results[0];
+            results = {
                 ...result,
                 currentReport: {
                     ...result.currentReport,
@@ -194,7 +190,15 @@ const _getReportsForStrategy = async (
                 duration: parseInt(result.duration),
                 durationPr: parseFloat(result.durationPr),
                 apr: parseFloat(result.apr) * 100,
-            },
+            };
+        }
+        return {
+            ...(omit(report, OMIT_FIELDS) as StratReportGraphType),
+            profit: report.gain,
+            loss: report.loss,
+            totalProfit: report.totalGain,
+            transactionHash: report.transaction.hash,
+            results,
         };
     });
     return values;


### PR DESCRIPTION
The query to get the APRs looks for the last 10 reports. In case the strategy has less than 10 reports, the first report doesn't include the APR result because it hasn't info to compare with (it is calculated comparing a report against the previous one).

It fixes the issue not displaying the APR info in case it is the first report.