### PR TITLE
Fix: Use Contract Calls to get Fees 

### DIFF
--- a/src/utils/ABI/VaultAPI_032.json
+++ b/src/utils/ABI/VaultAPI_032.json
@@ -75,6 +75,22 @@
       "type": "function"
     },
     {
+      "stateMutability": "view",
+      "type": "function",
+      "name": "managementFee",
+      "inputs": [],
+      "outputs": [{ "name": "", "type": "uint256" }],
+      "gas": 4248
+    },
+    {
+      "stateMutability": "view",
+      "type": "function",
+      "name": "performanceFee",
+      "inputs": [],
+      "outputs": [{ "name": "", "type": "uint256" }],
+      "gas": 4278
+    },
+    {
       "inputs": [],
       "name": "apiVersion",
       "outputs": [

--- a/src/utils/checks.ts
+++ b/src/utils/checks.ts
@@ -16,7 +16,7 @@ const TREASURY = '0x93a62da5a14c80f265dabc077fcee437b1a0efde';
 
 const MANAGEMENT_FEE = 200;
 
-const PERF_FEE = 2000;
+const PERF_FEE = 1000;
 
 const addressMap = new Map<string, string>();
 addressMap.set(GOVERNANCE.toLowerCase(), 'ychad.eth');


### PR DESCRIPTION
It includes:

- Use multicall to get performance and management fees.
- Change the default value (performance fee) to 10% (instead of 20% - it a consolidated value = yearn + strategist). 