### PR TITLE
remove linter warnings

### DIFF
--- a/src/components/app/SingleStrategy/BreadCrumbs.tsx
+++ b/src/components/app/SingleStrategy/BreadCrumbs.tsx
@@ -23,7 +23,7 @@ const useStyles = makeStyles((theme: Theme) =>
 type BreadCrumbsProps = {
     vaultId: string;
     strategyId?: string;
-    network?: string;
+    network?: Network;
 };
 const BreadCrumbs = (props: BreadCrumbsProps) => {
     const { vaultId, strategyId, network = 'ethereum' } = props;

--- a/src/components/app/SingleStrategy/index.tsx
+++ b/src/components/app/SingleStrategy/index.tsx
@@ -111,8 +111,7 @@ export const SingleStrategy = () => {
         setValue(newValue);
     };
 
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const handleCloseSnackBar = (event: any) => {
+    const handleCloseSnackBar = () => {
         setOpenSB(false);
     };
 

--- a/src/components/app/SingleVault/index.tsx
+++ b/src/components/app/SingleVault/index.tsx
@@ -157,7 +157,7 @@ export const SingleVault = (props: SingleVaultProps) => {
         setValue(newValue);
     };
 
-    const handleCloseSnackBar = (event: any) => {
+    const handleCloseSnackBar = () => {
         setOpenSB(false);
     };
 


### PR DESCRIPTION
There were some linter warnings, which this PR removes.

```
src/components/app/SingleStrategy/BreadCrumbs.tsx
  Line 6:10:  'Network' is defined but never used  @typescript-eslint/no-unused-vars

src/components/app/SingleStrategy/index.tsx
  Line 115:41:  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

src/components/app/SingleVault/index.tsx
  Line 160:34:  'event' is defined but never used         @typescript-eslint/no-unused-vars
  Line 160:41:  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
```

Regarding `handleCloseSnackBar`, I can also silence the warnings with `// eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-explicit-any`, but the signature was wrong anyway - it is `(event, reason)` for `onClose` handler.