### PR TITLE
Use react router links to avoid rerendering entire site on navigation

### DIFF
--- a/src/components/app/NavBar/index.tsx
+++ b/src/components/app/NavBar/index.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect } from 'react';
+import { Link as RouterLink } from 'react-router-dom';
 import { makeStyles } from '@material-ui/core/styles';
 import { useLocation } from 'react-router-dom';
 import AppBar from '@material-ui/core/AppBar';
@@ -74,7 +75,7 @@ export const NavBar: React.FC<NavBarProps> = ({ themeToggler, theme }) => {
             <StyledAppBar position="static" elevation={0}>
                 <Toolbar>
                     <div className={classes.img}>
-                        <Link href="/">
+                        <Link component={RouterLink} to="/">
                             <StyledImg
                                 alt="yearn watch"
                                 src={

--- a/src/components/app/SingleStrategy/BreadCrumbs.tsx
+++ b/src/components/app/SingleStrategy/BreadCrumbs.tsx
@@ -1,3 +1,4 @@
+import { Link as RouterLink } from 'react-router-dom';
 import { makeStyles, Theme, createStyles } from '@material-ui/core/styles';
 import Hidden from '@material-ui/core/Hidden';
 import MuiBreadcrumbs from '@material-ui/core/Breadcrumbs';
@@ -33,8 +34,9 @@ const BreadCrumbs = (props: BreadCrumbsProps) => {
     if (strategyId !== undefined) {
         strategyLevel = (
             <Link
+                component={RouterLink}
                 color="inherit"
-                href={`/network/${network}/vault/${vaultId.toLowerCase()}/strategy/${strategyId.toLowerCase()}`}
+                to={`/network/${network}/vault/${vaultId.toLowerCase()}/strategy/${strategyId.toLowerCase()}`}
             >
                 <Typography className={classes.text}>
                     <Hidden smUp>{`${extractAddress(
@@ -48,12 +50,17 @@ const BreadCrumbs = (props: BreadCrumbsProps) => {
 
     return (
         <MuiBreadcrumbs className={classes.crumbs}>
-            <Link color="inherit" href={`/network/${network}`}>
+            <Link
+                component={RouterLink}
+                color="inherit"
+                to={`/network/${network}`}
+            >
                 vaults
             </Link>
             <Link
+                component={RouterLink}
                 color="inherit"
-                href={`/network/${network}/vault/${vaultId.toLowerCase()}`}
+                to={`/network/${network}/vault/${vaultId.toLowerCase()}`}
             >
                 <Hidden smUp>{`${extractAddress(
                     vaultId.toLowerCase()

--- a/src/components/app/StrategiesList/index.tsx
+++ b/src/components/app/StrategiesList/index.tsx
@@ -1,10 +1,15 @@
-import { memo } from 'react';
+import { forwardRef, memo } from 'react';
+import {
+    Link as RouterLink,
+    LinkProps as RouterLinkProps,
+} from 'react-router-dom';
 
 import Typography from '@material-ui/core/Typography';
 import styled from 'styled-components';
 import MuiAccordion from '@material-ui/core/Accordion';
 import AccordionSummary from '@material-ui/core/AccordionSummary';
 import AccordionDetails from '@material-ui/core/AccordionDetails';
+import Link, { LinkBaseProps } from '@material-ui/core/Link';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import Hidden from '@material-ui/core/Hidden';
 import EtherScanLink from '../../common/EtherScanLink';
@@ -105,8 +110,7 @@ const StyledTitleQueIndex = styled(Typography)<{ error: boolean }>`
             error ? theme.error : theme.title} !important;
     }
 `;
-
-const StyledLink = styled.a`
+const StyledLink = styled(Link)`
     && {
         font-family: Roboto;
         font-style: normal;
@@ -117,6 +121,12 @@ const StyledLink = styled.a`
         color: ${({ theme }) => theme.subtitle} !important;
     }
 `;
+
+const CustomLink = forwardRef<HTMLSpanElement, LinkBaseProps & RouterLinkProps>(
+    (props, ref) => <StyledLink component={RouterLink} ref={ref} {...props} />
+);
+CustomLink.displayName = 'CustomLink';
+
 const _StrategiesList = (props: StrategiesListProps) => {
     const { vault, network, expand = true } = props;
     const config = vault.configOK;
@@ -151,9 +161,8 @@ const _StrategiesList = (props: StrategiesListProps) => {
                                         <Grid item md={1}></Grid>
                                         <Grid item md={4} xs={12}>
                                             <StyledTitle>
-                                                <StyledLink
-                                                    href={`/network/${network}/vault/${strategy.vault}/strategy/${strategy.address}`}
-                                                    rel="noreferrer"
+                                                <CustomLink
+                                                    to={`/network/${network}/vault/${strategy.vault}/strategy/${strategy.address}`}
                                                 >
                                                     <Hidden smUp>
                                                         {strategy.name.length >
@@ -171,7 +180,7 @@ const _StrategiesList = (props: StrategiesListProps) => {
                                                     <HealthCheckIcon
                                                         strategy={strategy}
                                                     />
-                                                </StyledLink>
+                                                </CustomLink>
                                             </StyledTitle>
                                         </Grid>
                                         <Hidden xsDown>

--- a/src/components/app/VaultItemList/index.tsx
+++ b/src/components/app/VaultItemList/index.tsx
@@ -1,4 +1,5 @@
 import { Fragment, useState, memo } from 'react';
+import { Link as RouterLink } from 'react-router-dom';
 import styled from 'styled-components';
 import { withStyles } from '@material-ui/core/styles';
 
@@ -165,16 +166,15 @@ const _VaultItemList = (props: VaultItemListProps) => {
                                     ) : (
                                         ''
                                     )}
-                                    <a
-                                        href={`/network/${network}/vault/${vault.address}`}
-                                        rel="noreferrer"
+                                    <RouterLink
+                                        to={`/network/${network}/vault/${vault.address}`}
                                     >
                                         <StyledTextValue>
                                             {' '}
                                             {vault.name}
                                             {` v${vault.apiVersion}`}
                                         </StyledTextValue>
-                                    </a>
+                                    </RouterLink>
                                     <br />
                                     <StyledStrats>
                                         {` ${vault.strategies.length}  strats`}

--- a/src/components/common/EtherScanLink/index.tsx
+++ b/src/components/common/EtherScanLink/index.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { MouseEvent, useEffect, useState } from 'react';
+import React, { MouseEvent, useEffect, useState } from 'react';
+import { Link as RouterLink } from 'react-router-dom';
 import styled from 'styled-components';
 import Button from '@material-ui/core/Button';
 import { extractAddress } from '../../../utils/commonUtils';
@@ -92,7 +92,11 @@ const EtherScanLink = (props: EtherScanLinkProps) => {
             <Grid item>
                 <StyledAddress>
                     {internalHref ? (
-                        <Link color="inherit" href={internalHref}>
+                        <Link
+                            component={RouterLink}
+                            color="inherit"
+                            to={internalHref}
+                        >
                             <Hidden smUp>{maskedValue}</Hidden>
                             <Hidden xsDown>{value}</Hidden>
                         </Link>

--- a/src/components/common/VaultsList/index.tsx
+++ b/src/components/common/VaultsList/index.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback, useMemo, memo } from 'react';
+import { Link as RouterLink } from 'react-router-dom';
 import { makeStyles, Theme, createStyles } from '@material-ui/core/styles';
 import styled from 'styled-components';
 import sum from 'lodash/sum';
@@ -179,7 +180,10 @@ const _VaultsList = (props: VaultsListProps) => {
                 ))}
             </div>
             <StyledContainer>
-                <Button color="inherit" href={`/network/${network}/report`}>
+                <Button
+                    component={RouterLink}
+                    to={`/network/${network}/report`}
+                >
                     <Typography className={classes.text}>Report</Typography>
                 </Button>
             </StyledContainer>


### PR DESCRIPTION
Right now we use the MaterialUI Link component or HTML `<a>` tags to jump between internal pages, which will cause the entire React app to re-render whenever we navigate to a new page.

This will clear any caches/memoized functions and cause navigation to be slightly slower in general because all components including common ones (eg. NavBar, ThemeProvider) will need to render again.