### PR TITLE
feat: add gen lender tab to strategy page

### DIFF
--- a/src/components/app/SingleStrategy/CardContent.tsx
+++ b/src/components/app/SingleStrategy/CardContent.tsx
@@ -23,6 +23,7 @@ const StyledTableRow = styled(TableRow)`
 `;
 const StyledTableCell = styled(TableCell)`
     && {
+        vertical-align: top;
         border-bottom: 1px solid ${({ theme }) => theme.border} !important;
     }
 `;

--- a/src/components/app/SingleStrategy/GenLender.tsx
+++ b/src/components/app/SingleStrategy/GenLender.tsx
@@ -1,0 +1,91 @@
+import styled from 'styled-components';
+import Typography from '@material-ui/core/Typography';
+import { useEffect, useState } from 'react';
+
+import CardContent from './CardContent';
+import { ErrorAlert } from '../../common/Alerts';
+import { GenLenderStrategy, Network, Strategy } from '../../../types';
+import { displayAmount, displayAprAmount } from '../../../utils/commonUtils';
+import { getError } from '../../../utils/error';
+import { getGenLenderStrategy } from '../../../utils/strategies';
+
+const StyledTypography = styled(Typography)`
+    && {
+        color: ${({ theme }) => theme.title};
+        margin-top: 20px;
+        margin-bottom: 20px;
+        text-align: center;
+    }
+`;
+
+type GenLenderProps = {
+    strategy: Strategy;
+    network: Network;
+};
+
+export const GenLender = (props: GenLenderProps) => {
+    const { strategy, network } = props;
+    const [isLoading, setIsLoading] = useState(true);
+    const [genLenderData, setGenLenderData] = useState<GenLenderStrategy>();
+    const [error, setError] = useState('');
+
+    useEffect(() => {
+        const loadGenLenderData = async () => {
+            try {
+                const loadedGenLenderData = await getGenLenderStrategy(
+                    strategy.address,
+                    network
+                );
+                console.log(loadedGenLenderData);
+                setGenLenderData(loadedGenLenderData);
+                setIsLoading(false);
+            } catch (e: unknown) {
+                console.log('Error:', e);
+                setIsLoading(false);
+                setError(getError(e));
+            }
+        };
+        loadGenLenderData();
+    }, [strategy.address, network]);
+
+    const renderData = () => {
+        const estimateAdjustPosition = genLenderData
+            ? genLenderData.estimateAdjustPosition.toString()
+            : '';
+
+        const estimatedAPR = genLenderData
+            ? displayAprAmount(
+                  genLenderData.estimatedAPR.toString(),
+                  strategy.token.decimals
+              )
+            : '';
+
+        const lentTotalAssets = genLenderData
+            ? displayAmount(
+                  genLenderData.lentTotalAssets.toString(),
+                  strategy.token.decimals
+              )
+            : '';
+
+        const data = [
+            { key: 'Estimate Adjust Position:', value: estimateAdjustPosition },
+            { key: 'Estimated APR', value: `${estimatedAPR}%` },
+            { key: 'Total Assets Lent:', value: lentTotalAssets },
+        ];
+        return <CardContent data={data} key={strategy.address} />;
+    };
+
+    return (
+        <>
+            {isLoading ? (
+                <StyledTypography>Loading...</StyledTypography>
+            ) : error ? (
+                <ErrorAlert message={error} />
+            ) : (
+                renderData()
+            )}
+        </>
+    );
+};
+
+export default GenLender;

--- a/src/components/app/SingleStrategy/GenLender.tsx
+++ b/src/components/app/SingleStrategy/GenLender.tsx
@@ -36,7 +36,6 @@ export const GenLender = (props: GenLenderProps) => {
                     strategy.address,
                     network
                 );
-                console.log(loadedGenLenderData);
                 setGenLenderData(loadedGenLenderData);
                 setIsLoading(false);
             } catch (e: unknown) {
@@ -54,10 +53,7 @@ export const GenLender = (props: GenLenderProps) => {
             : '';
 
         const estimatedAPR = genLenderData
-            ? displayAprAmount(
-                  genLenderData.estimatedAPR.toString(),
-                  strategy.token.decimals
-              )
+            ? displayAprAmount(genLenderData.estimatedAPR.toString())
             : '';
 
         const lentTotalAssets = genLenderData

--- a/src/components/app/SingleStrategy/GenLender.tsx
+++ b/src/components/app/SingleStrategy/GenLender.tsx
@@ -8,6 +8,8 @@ import { GenLenderStrategy, Network, Strategy } from '../../../types';
 import { displayAmount, displayAprAmount } from '../../../utils/commonUtils';
 import { getError } from '../../../utils/error';
 import { getGenLenderStrategy } from '../../../utils/strategies';
+import { Box } from '@material-ui/core';
+import EtherScanLink from '../../common/EtherScanLink';
 
 const StyledTypography = styled(Typography)`
     && {
@@ -48,13 +50,43 @@ export const GenLender = (props: GenLenderProps) => {
     }, [strategy.address, network]);
 
     const renderData = () => {
-        const estimateAdjustPosition = genLenderData
-            ? genLenderData.estimateAdjustPosition.toString()
-            : '';
-
-        const estimatedAPR = genLenderData
-            ? displayAprAmount(genLenderData.estimatedAPR.toString())
-            : '';
+        const lenderStatuses =
+            genLenderData && genLenderData.lendStatuses ? (
+                <>
+                    {genLenderData.lendStatuses.map((value, index) => (
+                        <Box
+                            key={`lender_${value[0]}`}
+                            sx={{
+                                marginBottom:
+                                    index ===
+                                    genLenderData.lendStatuses.length - 1
+                                        ? '0'
+                                        : '20px',
+                            }}
+                        >
+                            <div>
+                                <div>{value[0]}</div>
+                                <EtherScanLink
+                                    address={value[3]}
+                                    network={network}
+                                />
+                            </div>
+                            <div>
+                                {'  '}Deposits:{' '}
+                                {displayAmount(
+                                    value[1].toString(),
+                                    strategy.token.decimals
+                                )}
+                            </div>
+                            <div>
+                                APR: {displayAprAmount(value[2].toString())}%
+                            </div>
+                        </Box>
+                    ))}
+                </>
+            ) : (
+                ''
+            );
 
         const lentTotalAssets = genLenderData
             ? displayAmount(
@@ -63,10 +95,44 @@ export const GenLender = (props: GenLenderProps) => {
               )
             : '';
 
+        const estimatedAPR = genLenderData
+            ? displayAprAmount(genLenderData.estimatedAPR.toString())
+            : '';
+
+        const estimateAdjustPositionLowest = genLenderData
+            ? genLenderData.estimateAdjustPosition[0].toString()
+            : '';
+
+        const estimateAdjustPositionHighest = genLenderData
+            ? genLenderData.estimateAdjustPosition[2].toString()
+            : '';
+
+        const estimateAdjustPositionLowestAPR = genLenderData
+            ? displayAprAmount(
+                  genLenderData.estimateAdjustPosition[1].toString()
+              )
+            : '';
+
+        const estimateAdjustPositionPotential = genLenderData
+            ? displayAprAmount(
+                  genLenderData.estimateAdjustPosition[3].toString()
+              )
+            : '';
+
         const data = [
+            { key: 'Lender Statuses:', value: lenderStatuses },
             { key: 'Total Assets Lent:', value: lentTotalAssets },
             { key: 'Estimated APR', value: `${estimatedAPR}%` },
-            { key: 'Estimate Adjust Position:', value: estimateAdjustPosition },
+            { key: 'Lowest Lender:', value: estimateAdjustPositionLowest },
+            { key: 'Highest Lender:', value: estimateAdjustPositionHighest },
+            {
+                key: 'Lowest APR:',
+                value: `${estimateAdjustPositionLowestAPR}%`,
+            },
+            {
+                key: 'Potential:',
+                value: `${estimateAdjustPositionPotential}%`,
+            },
         ];
         return <CardContent data={data} key={strategy.address} />;
     };

--- a/src/components/app/SingleStrategy/GenLender.tsx
+++ b/src/components/app/SingleStrategy/GenLender.tsx
@@ -64,9 +64,9 @@ export const GenLender = (props: GenLenderProps) => {
             : '';
 
         const data = [
-            { key: 'Estimate Adjust Position:', value: estimateAdjustPosition },
-            { key: 'Estimated APR', value: `${estimatedAPR}%` },
             { key: 'Total Assets Lent:', value: lentTotalAssets },
+            { key: 'Estimated APR', value: `${estimatedAPR}%` },
+            { key: 'Estimate Adjust Position:', value: estimateAdjustPosition },
         ];
         return <CardContent data={data} key={strategy.address} />;
     };

--- a/src/types/strategy.ts
+++ b/src/types/strategy.ts
@@ -43,3 +43,18 @@ export type Strategy = {
     params: StrategyParams;
     errors: string[];
 };
+
+export type LendStatus = {
+    name: string;
+    assets: BigNumber;
+    rate: BigNumber;
+    add: string;
+};
+
+export type GenLenderStrategy = {
+    address: string;
+    lendStatuses: LendStatus[];
+    lentTotalAssets: BigNumber;
+    estimatedAPR: BigNumber;
+    estimateAdjustPosition: BigNumber;
+};

--- a/src/types/strategy.ts
+++ b/src/types/strategy.ts
@@ -44,17 +44,24 @@ export type Strategy = {
     errors: string[];
 };
 
-export type LendStatus = {
-    name: string;
-    assets: BigNumber;
-    rate: BigNumber;
-    add: string;
-};
+export type LendStatus = [
+    name: string,
+    assets: BigNumber,
+    rate: BigNumber,
+    add: string
+];
+
+export type EstimateAdjustPosition = [
+    lowest: string,
+    lowestApr: BigNumber,
+    highest: BigNumber,
+    potential: string
+];
 
 export type GenLenderStrategy = {
     address: string;
     lendStatuses: LendStatus[];
     lentTotalAssets: BigNumber;
     estimatedAPR: BigNumber;
-    estimateAdjustPosition: BigNumber;
+    estimateAdjustPosition: EstimateAdjustPosition;
 };

--- a/src/utils/commonUtils.ts
+++ b/src/utils/commonUtils.ts
@@ -95,6 +95,10 @@ const _handleSingleValue = (value: unknown): unknown => {
 const _handleContractValues = (value: unknown): unknown => {
     if (Array.isArray(value)) {
         if (value.length === 1) {
+            if (Array.isArray(value[0])) {
+                // Preserve array nesting
+                return [_handleContractValues(value[0])];
+            }
             return _handleSingleValue(value[0]);
         }
         return value.map((v) => _handleContractValues(v));

--- a/src/utils/commonUtils.ts
+++ b/src/utils/commonUtils.ts
@@ -32,6 +32,7 @@ export const toDecimals = (amount: BigNumberish, decimals: number): BN => {
 };
 
 export const EMPTY_ADDRESS = '0x0000000000000000000000000000000000000000';
+export const STRATEGY_APR_DECIMALS = 18;
 
 export const extractAddress = (address: string) => {
     return (
@@ -64,7 +65,10 @@ export const displayAmount = (
     return display.toString();
 };
 
-export const displayAprAmount = (amount: string, decimals: number): string => {
+export const displayAprAmount = (
+    amount: string,
+    decimals = STRATEGY_APR_DECIMALS
+): string => {
     const newAmount = new BN(amount).times(100);
     return displayAmount(newAmount.toString(), decimals, 2);
 };

--- a/src/utils/commonUtils.ts
+++ b/src/utils/commonUtils.ts
@@ -64,6 +64,11 @@ export const displayAmount = (
     return display.toString();
 };
 
+export const displayAprAmount = (amount: string, decimals: number): string => {
+    const newAmount = new BN(amount).times(100);
+    return displayAmount(newAmount.toString(), decimals, 2);
+};
+
 export const msToHours = (ms: number): number => {
     return Number((ms / (1000 * 60 * 60)).toFixed(2));
 };


### PR DESCRIPTION
Fixes #133 

- Added a new `Gen Lender` tab to the strategy pages if applicable
  - Created an `AdditionalInfoLabels` enum so we can easily extend to other types of additional info later, depending on the contract type
- Added a GenLender component to be rendered in the tab
- Added a new util function to fetch gen lender data using a multicall
- Updated the `mapContractCalls` function to recursively handle array/tuple return values for gen lender data

![Screen Shot 2022-02-01 at 11 05 31 PM](https://user-images.githubusercontent.com/21136804/152101733-fd0374a7-4f9b-4463-beb8-a7017d8f4a80.png)