### PR TITLE
Add Debt Outstanding column in grouped strategies table

### DIFF
--- a/src/components/app/GenericList/EnhancedTableHead.tsx
+++ b/src/components/app/GenericList/EnhancedTableHead.tsx
@@ -11,7 +11,7 @@ import { HeadCell } from './HeadCell';
 import { GenericListItem } from '.'; // Data,
 import { HelpOutlineRounded } from '@material-ui/icons';
 
-interface EnhancedTableProps {
+interface EnhancedTableProps<ItemType extends GenericListItem> {
     classes: ReturnType<typeof useStyles>;
     onRequestSort: (
         event: React.MouseEvent<unknown>,
@@ -19,11 +19,13 @@ interface EnhancedTableProps {
     ) => void;
     order: Order;
     orderBy: string;
-    headCells: HeadCell[];
+    headCells: HeadCell<ItemType>[];
     shouldCollapse?: boolean;
 }
 
-export const EnhancedTableHead = (props: EnhancedTableProps) => {
+export const EnhancedTableHead = <T extends GenericListItem>(
+    props: EnhancedTableProps<T>
+) => {
     const {
         classes,
         order,

--- a/src/components/app/GenericList/HeadCell.tsx
+++ b/src/components/app/GenericList/HeadCell.tsx
@@ -6,7 +6,7 @@ export type CellPosition = {
     rowNumber: number;
     columnNumber: number;
 };
-export interface HeadCell {
+export interface HeadCell<ItemType extends GenericListItem> {
     disablePadding: boolean;
     id?: keyof GenericListItem;
     label: string;
@@ -15,9 +15,9 @@ export interface HeadCell {
     tooltip?: string;
     // Format a value
     format?: (
-        item: GenericListItem,
+        item: ItemType,
         value: string | number | boolean,
         position: CellPosition
     ) => any;
-    getStyle?: (item: GenericListItem, position: CellPosition) => any;
+    getStyle?: (item: ItemType, position: CellPosition) => any;
 }

--- a/src/components/app/GenericList/ItemRow.tsx
+++ b/src/components/app/GenericList/ItemRow.tsx
@@ -12,7 +12,7 @@ import KeyboardArrowDownIcon from '@material-ui/icons/KeyboardArrowDown';
 import KeyboardArrowUpIcon from '@material-ui/icons/KeyboardArrowUp';
 
 export interface ItemRowProps<ItemType extends GenericListItem> {
-    headCells: HeadCell[];
+    headCells: HeadCell<ItemType>[];
     item: ItemType;
     index: number;
     collapse?: (index: number, item: ItemType) => React.ReactNode;

--- a/src/components/app/GenericList/index.tsx
+++ b/src/components/app/GenericList/index.tsx
@@ -23,7 +23,7 @@ export type GenericListItem = {
 type GenericListProps<ItemType extends GenericListItem> = {
     items: Array<ItemType>;
     collapse?: (index: number, item: ItemType) => React.ReactNode;
-    headCells: HeadCell[];
+    headCells: HeadCell<ItemType>[];
     title: string;
     defaultRowsPerPage?: number;
     displayPagination?: boolean;
@@ -133,7 +133,7 @@ export const GenericList = <T extends GenericListItem>(
                         rowsPerPage={rowsPerPage}
                         page={page}
                         onPageChange={handleChangePage}
-                        onChangeRowsPerPage={handleChangeRowsPerPage}
+                        onRowsPerPageChange={handleChangeRowsPerPage}
                     />
                 ) : (
                     ''

--- a/src/components/app/HealthCheckReport/index.tsx
+++ b/src/components/app/HealthCheckReport/index.tsx
@@ -27,7 +27,7 @@ import { filterStrategiesByHealthCheck } from '../../../utils/vaults';
 
 const BATCH_NUMBER = 30;
 
-const headCells: HeadCell[] = [
+const headCells: HeadCell<GenericListItem>[] = [
     {
         numeric: false,
         disablePadding: false,

--- a/src/components/app/StrategyProtocolList/index.tsx
+++ b/src/components/app/StrategyProtocolList/index.tsx
@@ -11,7 +11,7 @@ import { getTvlImpact } from '../../../utils/risk';
 import { GenericList, GenericListItem } from '../GenericList';
 import { HeadCell } from '../GenericList/HeadCell';
 
-const headCells: HeadCell[] = [
+const headCells: HeadCell<StrategyTVLListItem>[] = [
     {
         numeric: false,
         disablePadding: false,
@@ -55,6 +55,23 @@ const headCells: HeadCell[] = [
         label: 'TVL %',
     },
     {
+        id: 'debtOutstandingUsdcNumber',
+        numeric: true,
+        disablePadding: false,
+        align: 'center',
+        label: 'Debt Outstanding (MM)',
+        getStyle: (item: StrategyTVLListItem) => {
+            const hasHighDebtToAssetsRatio =
+                item.debtOutstandingUsdcNumber >
+                1.5 * item.estimatedTotalAssetsUsdcNumber;
+            return hasHighDebtToAssetsRatio
+                ? {
+                      backgroundColor: '#f5f514',
+                  }
+                : {};
+        },
+    },
+    {
         id: 'tvlImpact',
         numeric: true,
         disablePadding: false,
@@ -93,29 +110,73 @@ type StrategyProtocolListProps = {
     item: ProtocolTVL;
 };
 
+type StrategyTVLListItem = {
+    vault: string;
+    network: string;
+    strategy: string;
+    name: string;
+    activation: number;
+    activationStr: string;
+    estimatedTotalAssetsUsdcNumber: number;
+    totalTvlPercentage: number;
+    debtOutstandingUsdcNumber: number;
+    dustUsdcNumber: number;
+    tvlImpact: number;
+};
+
 export const StrategyProtocolList = (props: StrategyProtocolListProps) => {
     const { network = DEFAULT_NETWORK } = useParams<ParamTypes>();
 
     const classes = useStyles();
-    const strategies = props.item.strategies.map((strategyTVL) => {
-        const amountInMMs = amountToMMs(strategyTVL.estimatedTotalAssetsUsdc);
-        return {
-            vault: strategyTVL.vault,
-            network,
-            strategy: strategyTVL.address,
-            name: strategyTVL.name,
-            activation: Date.parse(strategyTVL.params.activation),
-            activationStr: strategyTVL.params.activation,
-            estimatedTotalAssetsUsdcNumber: amountInMMs,
-            totalTvlPercentage: strategyTVL.estimatedTotalAssetsUsdc.isZero()
-                ? strategyTVL.estimatedTotalAssetsUsdc.toNumber()
-                : strategyTVL.estimatedTotalAssetsUsdc
-                      .times(100)
-                      .div(props.item.tvl)
-                      .toNumber(),
-            tvlImpact: getTvlImpact(amountInMMs),
-        };
-    });
+    const strategies: StrategyTVLListItem[] = props.item.strategies.map(
+        (strategyTVL) => {
+            const assetsInMMs = amountToMMs(
+                strategyTVL.estimatedTotalAssetsUsdc
+            );
+            const debtInMMs = amountToMMs(strategyTVL.debtOutstandingUsdc);
+            return {
+                vault: strategyTVL.vault,
+                network,
+                strategy: strategyTVL.address,
+                name: strategyTVL.name,
+                activation: Date.parse(strategyTVL.params.activation),
+                activationStr: strategyTVL.params.activation,
+                estimatedTotalAssetsUsdcNumber: assetsInMMs,
+                totalTvlPercentage:
+                    strategyTVL.estimatedTotalAssetsUsdc.isZero()
+                        ? strategyTVL.estimatedTotalAssetsUsdc.toNumber()
+                        : strategyTVL.estimatedTotalAssetsUsdc
+                              .times(100)
+                              .div(props.item.tvl)
+                              .toNumber(),
+                debtOutstandingUsdcNumber: debtInMMs,
+                dustUsdcNumber: strategyTVL.dustUsdc.toNumber(),
+                tvlImpact: getTvlImpact(assetsInMMs),
+            };
+        }
+    );
+
+    /**
+     * Returns true based on the following formula
+     * totalAssets > 2 * totalDebt && totalAssets > Dust
+     * @param item
+     */
+    const hasHealthyAssetsToDebtRatio = async (item: StrategyTVLListItem) => {
+        return (
+            item.estimatedTotalAssetsUsdcNumber >
+                item.debtOutstandingUsdcNumber * 2 &&
+            item.estimatedTotalAssetsUsdcNumber > item.dustUsdcNumber
+        );
+    };
+
+    const getRowStyle = (_index: number, item: StrategyTVLListItem) => {
+        if (!hasHealthyAssetsToDebtRatio(item)) {
+            return {
+                borderColor: 'red',
+                borderStyle: 'groove',
+            };
+        }
+    };
 
     return (
         <div className={classes.root}>
@@ -128,6 +189,7 @@ export const StrategyProtocolList = (props: StrategyProtocolListProps) => {
                 defaultOrder="desc"
                 defaultOrderBy="estimatedTotalAssetsUsdcNumber"
                 defaultRowsPerPage={20}
+                getRowStyle={getRowStyle}
             />
         </div>
     );

--- a/src/components/app/StrategyProtocolList/index.tsx
+++ b/src/components/app/StrategyProtocolList/index.tsx
@@ -11,6 +11,9 @@ import { getTvlImpact } from '../../../utils/risk';
 import { GenericList, GenericListItem } from '../GenericList';
 import { HeadCell } from '../GenericList/HeadCell';
 
+const HIGH_DEBT_TO_ASSETS_RATIO = 1.5;
+const HEALTHY_DEBT_MULTIPLIER = 2;
+
 const headCells: HeadCell<StrategyTVLListItem>[] = [
     {
         numeric: false,
@@ -63,7 +66,7 @@ const headCells: HeadCell<StrategyTVLListItem>[] = [
         getStyle: (item: StrategyTVLListItem) => {
             const hasHighDebtToAssetsRatio =
                 item.debtOutstandingUsdcNumber >
-                1.5 * item.estimatedTotalAssetsUsdcNumber;
+                HIGH_DEBT_TO_ASSETS_RATIO * item.estimatedTotalAssetsUsdcNumber;
             return hasHighDebtToAssetsRatio
                 ? {
                       backgroundColor: '#f5f514',
@@ -164,7 +167,7 @@ export const StrategyProtocolList = (props: StrategyProtocolListProps) => {
     const hasHealthyAssetsToDebtRatio = async (item: StrategyTVLListItem) => {
         return (
             item.estimatedTotalAssetsUsdcNumber >
-                item.debtOutstandingUsdcNumber * 2 &&
+                HEALTHY_DEBT_MULTIPLIER * item.debtOutstandingUsdcNumber &&
             item.estimatedTotalAssetsUsdcNumber > item.dustUsdcNumber
         );
     };

--- a/src/components/app/StrategyProtocolList/index.tsx
+++ b/src/components/app/StrategyProtocolList/index.tsx
@@ -137,6 +137,7 @@ export const StrategyProtocolList = (props: StrategyProtocolListProps) => {
                 strategyTVL.estimatedTotalAssetsUsdc
             );
             const debtInMMs = amountToMMs(strategyTVL.debtOutstandingUsdc);
+            const dustInMMs = amountToMMs(strategyTVL.dustUsdc);
             return {
                 vault: strategyTVL.vault,
                 network,
@@ -153,7 +154,7 @@ export const StrategyProtocolList = (props: StrategyProtocolListProps) => {
                               .div(props.item.tvl)
                               .toNumber(),
                 debtOutstandingUsdcNumber: debtInMMs,
-                dustUsdcNumber: strategyTVL.dustUsdc.toNumber(),
+                dustUsdcNumber: dustInMMs,
                 tvlImpact: getTvlImpact(assetsInMMs),
             };
         }

--- a/src/components/common/LongevityTooltip/index.tsx
+++ b/src/components/common/LongevityTooltip/index.tsx
@@ -4,7 +4,7 @@ import { HelpOutlined } from '@material-ui/icons';
 import { GenericList, GenericListItem } from '../../app';
 import { HeadCell } from '../../app/GenericList/HeadCell';
 
-export const headCells: HeadCell[] = [
+export const headCells: HeadCell<GenericListItem>[] = [
     {
         id: 'description',
         numeric: false,

--- a/src/components/common/RiskChart/index.tsx
+++ b/src/components/common/RiskChart/index.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/jsx-key */
 /* eslint-disable react/display-name */
-import { GenericList, GenericListItem } from '../../app/GenericList';
+import { GenericList, GenericListItem } from '../../app';
 import { CellPosition, HeadCell } from '../../app/GenericList/HeadCell';
 import { colors, getSemaphoreInfo } from '../Semaphore';
 
@@ -28,7 +28,7 @@ const GroupQueryLink = (props: GroupQueryLinkProps) => {
     return <li key={keyValue}>{groupLabel}</li>;
 };
 
-export const headCells: HeadCell[] = [
+export const headCells: HeadCell<GenericListItem>[] = [
     {
         id: 'label',
         numeric: true,

--- a/src/components/common/TVLImpactTooltip/index.tsx
+++ b/src/components/common/TVLImpactTooltip/index.tsx
@@ -4,7 +4,7 @@ import { HelpOutlined } from '@material-ui/icons';
 import { GenericList, GenericListItem } from '../../app';
 import { HeadCell } from '../../app/GenericList/HeadCell';
 
-export const headCells: HeadCell[] = [
+export const headCells: HeadCell<GenericListItem>[] = [
     {
         id: 'label',
         numeric: false,

--- a/src/components/common/headers/scoresHeaderDefinition.tsx
+++ b/src/components/common/headers/scoresHeaderDefinition.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/display-name */
 import { Tooltip } from '@material-ui/core';
-import { GenericListItem } from '../../app/GenericList';
+import { GenericListItem } from '../../app';
 import { Link } from 'react-router-dom';
 import MonetizationOnRoundedIcon from '@material-ui/icons/MonetizationOnRounded';
 import { HeadCell } from '../../app/GenericList/HeadCell';
@@ -9,7 +9,7 @@ import { TVLImpactTooltip } from '../TVLImpactTooltip';
 import { amountToMMs } from '../../../utils/commonUtils';
 import BigNumber from 'bignumber.js';
 
-export const scoreHeadCells: HeadCell[] = [
+export const scoreHeadCells: HeadCell<GenericListItem>[] = [
     {
         numeric: false,
         disablePadding: false,

--- a/src/types/strategy-tvl.ts
+++ b/src/types/strategy-tvl.ts
@@ -3,4 +3,6 @@ import { Strategy } from '.';
 
 export type StrategyTVL = Strategy & {
     estimatedTotalAssetsUsdc: BigNumber;
+    debtOutstandingUsdc: BigNumber;
+    dustUsdc: BigNumber;
 };


### PR DESCRIPTION
Fixes #120 .

- [x] Add Debt Outstanding column to grouped strategy table
- [x] Add field highlighting based on debt to assets ratio
- [x] Fixed a warning about a deprecated react event handler (onRowsPerPageChange)
- [x] Add row highlighting based on assets to dust ratio

*Note:* as part of the cleanup I added a generic type parameter to HeadCell to support typed `GenericListItem` s. Hope that's okay.