### PR TITLE
fix: clean up some styles and console errors

### DIFF
--- a/src/components/app/Charts/Pie/BarChart.tsx
+++ b/src/components/app/Charts/Pie/BarChart.tsx
@@ -43,7 +43,6 @@ export default function BarChart(props: BarChartProps) {
                                 <SubTitle>{val.name}</SubTitle>
                             </Grid>
                             <Grid item xs={6}>
-                                {' '}
                                 <ValuePercentage>{val.y} %</ValuePercentage>
                             </Grid>
                         </Grid>

--- a/src/components/app/Charts/Pie/index.tsx
+++ b/src/components/app/Charts/Pie/index.tsx
@@ -134,7 +134,6 @@ const Pie = (props: PieProps) => {
                 <Tab label="Pie chart" />
             </MuiTabs>
             <TabPanel value={value} index={0}>
-                {' '}
                 <BarChart data={DATA_CHART} />
             </TabPanel>
             <TabPanel value={value} index={1}>

--- a/src/components/app/GenericList/EnhancedTableHead.tsx
+++ b/src/components/app/GenericList/EnhancedTableHead.tsx
@@ -38,7 +38,7 @@ export const EnhancedTableHead = (props: EnhancedTableProps) => {
         };
 
     const collapseCell = shouldCollapse ? (
-        <TableCell key="collapse" align="center" padding="default">
+        <TableCell key="collapse" align="center" padding="normal">
             Details
         </TableCell>
     ) : (

--- a/src/components/app/GenericList/ItemRow.tsx
+++ b/src/components/app/GenericList/ItemRow.tsx
@@ -43,7 +43,7 @@ export const ItemRow = <T extends GenericListItem>(props: ItemRowProps<T>) => {
                 component="th"
                 id={labelId}
                 scope="row"
-                padding="default"
+                padding="normal"
                 key={itemRowKey}
                 align={headCell.align}
                 style={cellStyle}
@@ -59,7 +59,7 @@ export const ItemRow = <T extends GenericListItem>(props: ItemRowProps<T>) => {
             component="th"
             id={`collapse-${index}`}
             scope="row"
-            padding="default"
+            padding="normal"
             key={`collapse-${index}`}
             align="center"
         >

--- a/src/components/app/GenericList/index.tsx
+++ b/src/components/app/GenericList/index.tsx
@@ -133,7 +133,7 @@ export const GenericList = <T extends GenericListItem>(
                         rowsPerPage={rowsPerPage}
                         page={page}
                         onPageChange={handleChangePage}
-                        onChangeRowsPerPage={handleChangeRowsPerPage}
+                        onRowsPerPageChange={handleChangeRowsPerPage}
                     />
                 ) : (
                     ''

--- a/src/components/app/SingleStrategy/AccordionReport.tsx
+++ b/src/components/app/SingleStrategy/AccordionReport.tsx
@@ -92,7 +92,6 @@ const AccordionReport = (props: AccordionReportProps) => {
                                 />
 
                                 <StyledSubTypography>
-                                    {' '}
                                     Timestamp:
                                     <br />
                                     {unixMsToIsoString(res.timestamp)}

--- a/src/components/app/SingleStrategy/CardContent.tsx
+++ b/src/components/app/SingleStrategy/CardContent.tsx
@@ -43,20 +43,17 @@ const CardContent = (props: CardContentProps) => {
                             <StyledTableRow key={index}>
                                 <StyledTableCell>
                                     <SubTitle>
-                                        {' '}
                                         {res.key}
                                         <MediaQuery query="(max-device-width: 1224px)">
                                             <br />
                                             {res.value}
-                                        </MediaQuery>{' '}
+                                        </MediaQuery>
                                     </SubTitle>
                                 </StyledTableCell>
 
                                 <MediaQuery query="(min-device-width: 1224px)">
-                                    {' '}
                                     <StyledTableCell>
                                         <LabelTypography>
-                                            {' '}
                                             {res.value}
                                         </LabelTypography>
                                     </StyledTableCell>

--- a/src/components/app/SingleStrategy/GenLender.tsx
+++ b/src/components/app/SingleStrategy/GenLender.tsx
@@ -79,7 +79,7 @@ export const GenLender = (props: GenLenderProps) => {
                                 )}
                             </div>
                             <div>
-                                APR: {displayAprAmount(value[2].toString())}%
+                                APR: {displayAprAmount(value[2].toString())}
                             </div>
                         </Box>
                     ))}

--- a/src/components/app/SingleStrategy/index.tsx
+++ b/src/components/app/SingleStrategy/index.tsx
@@ -34,7 +34,11 @@ import StrategyDetail from './StrategyDetail';
 import StrategyHealthCheck from './StrategyHealthCheck';
 import StrategyReports from './StrategyReports';
 
-const StyledCard = styled(Card)<{ emergencyExit?: string }>`
+const StyledCard = styled(Card).withConfig({
+    shouldForwardProp: (props) => props.toString() !== 'emergencyExit',
+})<{
+    emergencyExit?: string;
+}>`
     && {
         background-color: ${({ theme }) => theme.container};
         color: ${({ theme }) => theme.title};
@@ -50,6 +54,7 @@ const StyledCard = styled(Card)<{ emergencyExit?: string }>`
         }
     }
 `;
+
 const StyledCardBreadCrumbs = styled(Card)`
     && {
         background-color: transparent;
@@ -66,6 +71,7 @@ const StyledCardBreadCrumbs = styled(Card)`
         }
     }
 `;
+
 const StyledSpan = styled.span`
     && {
         color: ${({ theme }) => theme.subtitle};
@@ -266,7 +272,6 @@ export const SingleStrategy = () => {
                                     strategy.emergencyExit.toString()
                                 }
                             >
-                                {' '}
                                 <CardHeader
                                     title={strategy ? strategy.name : ''}
                                     subheader={
@@ -314,7 +319,7 @@ export const SingleStrategy = () => {
                                 <div
                                     style={{
                                         height: '60vh',
-                                        overflow: 'scroll',
+                                        overflow: 'auto',
                                     }}
                                 >
                                     {renderTab(value)}

--- a/src/components/app/SingleVault/VaultDescription.tsx
+++ b/src/components/app/SingleVault/VaultDescription.tsx
@@ -20,15 +20,23 @@ interface VaultDescriptionProps {
     isLoading: boolean;
     network: Network;
 }
+
 const StyledTableRow = styled(TableRow)`
     && {
         background-color: ${({ theme }) => theme.body} !important;
     }
 `;
+
 const StyledTableCell = styled(TableCell)`
     && {
         /* color: ${({ theme }) => theme.title} !important; */
         border-bottom: 1px solid ${({ theme }) => theme.border} !important;
+    }
+`;
+
+const VaultContainer = styled.div`
+    && {
+        margin-top: 16px;
     }
 `;
 const renderErrors = (vault: Vault) =>
@@ -97,7 +105,7 @@ export const VaultDescription = (props: VaultDescriptionProps) => {
             '  ' +
             vault.token.symbol;
     const vault_list = vault
-        ? `Deposit limit :
+        ? `Deposit limit:
             ${
                 displayAmount(vault.depositLimit, vault.token.decimals) +
                 '  ' +
@@ -111,16 +119,15 @@ export const VaultDescription = (props: VaultDescriptionProps) => {
     const last_report_text = vault ? vault.lastReportText : '';
     const render_error = vault ? renderErrors(vault) : '';
     return (
-        <React.Fragment>
+        <VaultContainer>
             <Table>
                 <TableHead>
                     <StyledTableRow>
                         <StyledTableCell>
                             <SubTitle> API Version:</SubTitle>
                             <MediaQuery query="(max-device-width: 1224px)">
-                                <br />
                                 <LabelTypography>{api_version}</LabelTypography>
-                            </MediaQuery>{' '}
+                            </MediaQuery>
                         </StyledTableCell>
                         <MediaQuery query="(min-device-width: 1224px)">
                             <StyledTableCell>
@@ -132,14 +139,12 @@ export const VaultDescription = (props: VaultDescriptionProps) => {
                         <StyledTableCell>
                             <SubTitle> Emergency shut down:</SubTitle>
                             <MediaQuery query="(max-device-width: 1224px)">
-                                <br />{' '}
                                 <LabelTypography>
                                     {emergency_shut_down}
                                 </LabelTypography>
-                            </MediaQuery>{' '}
+                            </MediaQuery>
                         </StyledTableCell>
                         <MediaQuery query="(min-device-width: 1224px)">
-                            {' '}
                             <StyledTableCell>
                                 <LabelTypography>
                                     {emergency_shut_down}
@@ -151,13 +156,10 @@ export const VaultDescription = (props: VaultDescriptionProps) => {
                         <StyledTableCell>
                             <SubTitle>Governance:</SubTitle>
                             <MediaQuery query="(max-device-width: 1224px)">
-                                {' '}
-                                <br />
                                 <LabelTypography>{governance}</LabelTypography>
-                            </MediaQuery>{' '}
+                            </MediaQuery>
                         </StyledTableCell>
                         <MediaQuery query="(min-device-width: 1224px)">
-                            {' '}
                             <StyledTableCell>
                                 <LabelTypography>{governance}</LabelTypography>
                             </StyledTableCell>
@@ -167,14 +169,11 @@ export const VaultDescription = (props: VaultDescriptionProps) => {
                         <StyledTableCell>
                             <SubTitle>Management:</SubTitle>
                             <MediaQuery query="(max-device-width: 1224px)">
-                                {' '}
-                                <br />
                                 <LabelTypography>{management}</LabelTypography>
-                            </MediaQuery>{' '}
+                            </MediaQuery>
                         </StyledTableCell>
                         <MediaQuery query="(min-device-width: 1224px)">
                             <StyledTableCell>
-                                {' '}
                                 <LabelTypography>{management}</LabelTypography>
                             </StyledTableCell>
                         </MediaQuery>
@@ -184,17 +183,12 @@ export const VaultDescription = (props: VaultDescriptionProps) => {
                         <StyledTableCell>
                             <SubTitle>Guardian:</SubTitle>
                             <MediaQuery query="(max-device-width: 1224px)">
-                                <br />
                                 <LabelTypography>{guardian}</LabelTypography>
-                            </MediaQuery>{' '}
+                            </MediaQuery>
                         </StyledTableCell>
                         <MediaQuery query="(min-device-width: 1224px)">
-                            {' '}
                             <StyledTableCell>
-                                {' '}
-                                <LabelTypography>
-                                    {guardian}
-                                </LabelTypography>{' '}
+                                <LabelTypography>{guardian}</LabelTypography>
                             </StyledTableCell>
                         </MediaQuery>
                     </StyledTableRow>
@@ -202,17 +196,12 @@ export const VaultDescription = (props: VaultDescriptionProps) => {
                         <StyledTableCell>
                             <SubTitle>Rewards:</SubTitle>
                             <MediaQuery query="(max-device-width: 1224px)">
-                                <br />
                                 <LabelTypography>{rewards}</LabelTypography>
-                            </MediaQuery>{' '}
+                            </MediaQuery>
                         </StyledTableCell>
                         <MediaQuery query="(min-device-width: 1224px)">
-                            {' '}
                             <StyledTableCell>
-                                {' '}
-                                <LabelTypography>
-                                    {rewards}
-                                </LabelTypography>{' '}
+                                <LabelTypography>{rewards}</LabelTypography>
                             </StyledTableCell>
                         </MediaQuery>
                     </StyledTableRow>
@@ -220,11 +209,8 @@ export const VaultDescription = (props: VaultDescriptionProps) => {
                         <StyledTableCell>
                             <SubTitle>Assets:</SubTitle>
                             <MediaQuery query="(max-device-width: 1224px)">
-                                {' '}
-                                <br />
                                 <LabelTypography>
-                                    Total asset:
-                                    {total_asset}
+                                    Total assets: {total_asset}
                                 </LabelTypography>
                                 <ProgressBars vault={vault} />
                                 <LabelTypography>{vault_list}</LabelTypography>
@@ -233,9 +219,7 @@ export const VaultDescription = (props: VaultDescriptionProps) => {
                         <MediaQuery query="(min-device-width: 1224px)">
                             <StyledTableCell>
                                 <LabelTypography>
-                                    {' '}
-                                    Total asset:
-                                    {total_asset}
+                                    Total assets: {total_asset}
                                 </LabelTypography>
                                 <ProgressBars vault={vault} />
                                 <LabelTypography>{vault_list}</LabelTypography>
@@ -257,20 +241,16 @@ export const VaultDescription = (props: VaultDescriptionProps) => {
                         <StyledTableCell>
                             <SubTitle>Management fee:</SubTitle>
                             <MediaQuery query="(max-device-width: 1224px)">
-                                <br />
                                 <LabelTypography>
-                                    {' '}
                                     {management_fee} %
                                 </LabelTypography>
-                            </MediaQuery>{' '}
+                            </MediaQuery>
                         </StyledTableCell>
                         <MediaQuery query="(min-device-width: 1224px)">
-                            {' '}
                             <StyledTableCell>
-                                {' '}
                                 <LabelTypography>
                                     {management_fee}%
-                                </LabelTypography>{' '}
+                                </LabelTypography>
                             </StyledTableCell>
                         </MediaQuery>
                     </StyledTableRow>
@@ -278,14 +258,12 @@ export const VaultDescription = (props: VaultDescriptionProps) => {
                         <StyledTableCell>
                             <SubTitle>Performance fee:</SubTitle>
                             <MediaQuery query="(max-device-width: 1224px)">
-                                <br />
                                 <LabelTypography>
                                     {performance_fee}%
                                 </LabelTypography>
-                            </MediaQuery>{' '}
+                            </MediaQuery>
                         </StyledTableCell>
                         <MediaQuery query="(min-device-width: 1224px)">
-                            {' '}
                             <StyledTableCell>
                                 <LabelTypography>
                                     {performance_fee}%
@@ -297,14 +275,12 @@ export const VaultDescription = (props: VaultDescriptionProps) => {
                         <StyledTableCell>
                             <SubTitle> Time Since Last Report:</SubTitle>
                             <MediaQuery query="(max-device-width: 1224px)">
-                                <br />
                                 <LabelTypography>
                                     {last_report_text}
                                 </LabelTypography>
-                            </MediaQuery>{' '}
+                            </MediaQuery>
                         </StyledTableCell>
                         <MediaQuery query="(min-device-width: 1224px)">
-                            {' '}
                             <StyledTableCell>
                                 <LabelTypography>
                                     {last_report_text}
@@ -317,12 +293,10 @@ export const VaultDescription = (props: VaultDescriptionProps) => {
                         <StyledTableCell>
                             <SubTitle>Total Debt:</SubTitle>
                             <MediaQuery query="(max-device-width: 1224px)">
-                                <br />{' '}
                                 <LabelTypography>{total_debt}</LabelTypography>
-                            </MediaQuery>{' '}
+                            </MediaQuery>
                         </StyledTableCell>
                         <MediaQuery query="(min-device-width: 1224px)">
-                            {' '}
                             <StyledTableCell>
                                 <LabelTypography>{total_debt}</LabelTypography>
                             </StyledTableCell>
@@ -333,20 +307,12 @@ export const VaultDescription = (props: VaultDescriptionProps) => {
                         <StyledTableCell>
                             <SubTitle>{`(Total Asset - Total Debt):`}</SubTitle>
                             <MediaQuery query="(max-device-width: 1224px)">
-                                <br />{' '}
-                                <LabelTypography>
-                                    {' '}
-                                    {unallocated}
-                                </LabelTypography>
-                            </MediaQuery>{' '}
+                                <LabelTypography>{unallocated}</LabelTypography>
+                            </MediaQuery>
                         </StyledTableCell>
                         <MediaQuery query="(min-device-width: 1224px)">
-                            {' '}
                             <StyledTableCell>
-                                <LabelTypography>
-                                    {' '}
-                                    {unallocated}
-                                </LabelTypography>
+                                <LabelTypography>{unallocated}</LabelTypography>
                             </StyledTableCell>
                         </MediaQuery>
                     </StyledTableRow>
@@ -355,17 +321,12 @@ export const VaultDescription = (props: VaultDescriptionProps) => {
                         <StyledTableCell>
                             <SubTitle>Total Debt Ratio:</SubTitle>
                             <MediaQuery query="(max-device-width: 1224px)">
-                                <br />{' '}
                                 <LabelTypography>{debt_ratio}%</LabelTypography>
-                            </MediaQuery>{' '}
+                            </MediaQuery>
                         </StyledTableCell>
                         <MediaQuery query="(min-device-width: 1224px)">
-                            {' '}
                             <StyledTableCell>
-                                {' '}
-                                <LabelTypography>
-                                    {debt_ratio}%
-                                </LabelTypography>{' '}
+                                <LabelTypography>{debt_ratio}%</LabelTypography>
                             </StyledTableCell>
                         </MediaQuery>
                     </StyledTableRow>
@@ -374,18 +335,12 @@ export const VaultDescription = (props: VaultDescriptionProps) => {
                         <StyledTableCell>
                             <SubTitle>Debt Usage:</SubTitle>
                             <MediaQuery query="(max-device-width: 1224px)">
-                                <br />{' '}
                                 <LabelTypography>{debt_usage}%</LabelTypography>
-                            </MediaQuery>{' '}
+                            </MediaQuery>
                         </StyledTableCell>
                         <MediaQuery query="(min-device-width: 1224px)">
-                            {' '}
                             <StyledTableCell>
-                                {' '}
-                                <LabelTypography>
-                                    {' '}
-                                    {debt_usage}%{' '}
-                                </LabelTypography>
+                                <LabelTypography>{debt_usage}%</LabelTypography>
                             </StyledTableCell>
                         </MediaQuery>
                     </StyledTableRow>
@@ -399,25 +354,22 @@ export const VaultDescription = (props: VaultDescriptionProps) => {
                             <StyledTableCell>
                                 <SubTitle>Config Warnings:</SubTitle>
                                 <MediaQuery query="(max-device-width: 1224px)">
-                                    {' '}
-                                    <br />{' '}
                                     <LabelTypography>
                                         {render_error}
                                     </LabelTypography>
-                                </MediaQuery>{' '}
+                                </MediaQuery>
                             </StyledTableCell>
                             <MediaQuery query="(min-device-width: 1224px)">
-                                {' '}
                                 <StyledTableCell>
                                     <LabelTypography>
                                         {render_error}
-                                    </LabelTypography>{' '}
+                                    </LabelTypography>
                                 </StyledTableCell>
                             </MediaQuery>
                         </StyledTableRow>
                     ) : null}
                 </TableHead>
             </Table>
-        </React.Fragment>
+        </VaultContainer>
     );
 };

--- a/src/components/app/SingleVault/index.tsx
+++ b/src/components/app/SingleVault/index.tsx
@@ -26,7 +26,9 @@ import ReactHelmet from '../../common/ReactHelmet';
 import ProgressSpinnerBar from '../../common/ProgressSpinnerBar/ProgressSpinnerBar';
 import { GlobalStylesLoading } from '../../theme/globalStyles';
 
-const StyledCard = styled(Card)<{
+const StyledCard = styled(Card).withConfig({
+    shouldForwardProp: (props) => !(props.toString() in ['config', 'bck']),
+})<{
     config?: string | undefined;
     bck?: string | undefined;
 }>`
@@ -47,11 +49,13 @@ const StyledCard = styled(Card)<{
         }
     }
 `;
+
 const StyledSpan = styled.span`
     && {
         color: ${({ theme }) => theme.subtitle};
     }
 `;
+
 const MuiTabs = styled(Tabs)`
     && {
         color: ${({ theme }) => theme.subtitle}!important;
@@ -67,22 +71,19 @@ const MuiTabs = styled(Tabs)`
 const StyledPaper = styled(Paper)`
     && {
         background-color: ${({ theme }) => theme.body};
+        margin-top: 16px;
     }
 `;
-const TitleDetails = styled.span`
-    && {
-        color: ${({ theme }) => theme.title};
-        font-weight: bolder;
-        font-size: 20px;
-    }
-`;
+
 const StyledTitle = styled.span`
     && {
         color: ${({ theme }) => theme.title};
-        font-weight: bold;
-        font-size: 18px;
+        font-weight: 600;
+        font-size: 20px;
+        margin: 16px 0;
     }
 `;
+
 interface TabPanelProps {
     children?: React.ReactNode;
 
@@ -288,55 +289,35 @@ export const SingleVault = (props: SingleVaultProps) => {
                                 <TabPanel value={value} index={0}>
                                     <Grid container spacing={3}>
                                         <Grid item xs={12} md={6}>
-                                            <TitleDetails> About</TitleDetails>
-                                            <div
-                                                style={{
-                                                    height: '60vh',
-                                                    overflow: 'scroll',
-                                                }}
-                                            >
-                                                <VaultDescription
-                                                    vault={vault}
-                                                    isLoading={isLoading}
-                                                    network={network}
-                                                />
-                                            </div>
+                                            <StyledTitle> About</StyledTitle>
+                                            <VaultDescription
+                                                vault={vault}
+                                                isLoading={isLoading}
+                                                network={network}
+                                            />
                                         </Grid>
                                         <Grid item xs={12} md={6}>
-                                            <TitleDetails>
+                                            <StyledTitle>
                                                 {' '}
                                                 Strategy Allocation
-                                            </TitleDetails>
-                                            <div
-                                                style={{
-                                                    height: '60vh',
-                                                    overflow: 'scroll',
-                                                }}
-                                            >
-                                                <StyledPaper>
-                                                    {vault &&
-                                                    vault.strategies.length >
-                                                        0 ? (
-                                                        <Pie
-                                                            vault={vault}
-                                                            theme={props.theme}
-                                                        />
-                                                    ) : (
-                                                        ''
-                                                    )}
-                                                </StyledPaper>
-                                            </div>
+                                            </StyledTitle>
+                                            <StyledPaper>
+                                                {vault &&
+                                                vault.strategies.length > 0 ? (
+                                                    <Pie
+                                                        vault={vault}
+                                                        theme={props.theme}
+                                                    />
+                                                ) : (
+                                                    ''
+                                                )}
+                                            </StyledPaper>
                                         </Grid>
                                     </Grid>
                                 </TabPanel>
 
                                 <TabPanel value={value} index={1}>
-                                    <div
-                                        style={{
-                                            height: '60vh',
-                                            overflow: 'scroll',
-                                        }}
-                                    >
+                                    <div>
                                         {vault &&
                                         vault.strategies.length > 0 ? (
                                             <div>

--- a/src/components/app/StrategiesList/index.tsx
+++ b/src/components/app/StrategiesList/index.tsx
@@ -43,7 +43,9 @@ const StyledDivRoot = styled.div`
         border-radius: 5px;
     }
 `;
-const StyledMuiAccordion = styled(MuiAccordion)<{ config: string }>`
+const StyledMuiAccordion = styled(MuiAccordion).withConfig({
+    shouldForwardProp: (props) => !(props.toString() in ['config']),
+})<{ config: string }>`
     && {
         width: 100%;
         align-items: center;
@@ -89,7 +91,9 @@ const StyledTitle = styled(Typography)`
         color: ${({ theme }) => theme.title} !important;
     }
 `;
-const StyledSubtitleQueIndex = styled(Typography)<{ error: boolean }>`
+const StyledSubtitleQueIndex = styled(Typography).withConfig({
+    shouldForwardProp: (props) => !(props.toString() in ['error']),
+})<{ error: boolean }>`
     && {
         font-family: Roboto;
         font-style: normal;
@@ -101,7 +105,9 @@ const StyledSubtitleQueIndex = styled(Typography)<{ error: boolean }>`
             error ? theme.error : theme.subtitle} !important;
     }
 `;
-const StyledTitleQueIndex = styled(Typography)<{ error: boolean }>`
+const StyledTitleQueIndex = styled(Typography).withConfig({
+    shouldForwardProp: (props) => !(props.toString() in ['error']),
+})<{ error: boolean }>`
     && {
         font-family: Roboto;
         font-style: normal;
@@ -220,7 +226,6 @@ const _StrategiesList = (props: StrategiesListProps) => {
                                             </StyledTitle>
                                         </Grid>
                                         <Hidden xsDown>
-                                            {' '}
                                             <Grid item md={6} xs={9}>
                                                 <EtherScanLink
                                                     address={strategy.address}
@@ -253,7 +258,7 @@ const _StrategiesList = (props: StrategiesListProps) => {
                                         container
                                         spacing={1}
                                         direction="row"
-                                        justify="flex-start"
+                                        justifyContent="flex-start"
                                         alignItems="center"
                                     >
                                         <Grid item md={1}></Grid>
@@ -264,7 +269,7 @@ const _StrategiesList = (props: StrategiesListProps) => {
                                                         container
                                                         spacing={1}
                                                         direction="row"
-                                                        justify="flex-start"
+                                                        justifyContent="flex-start"
                                                         alignItems="center"
                                                     >
                                                         <Grid
@@ -309,7 +314,6 @@ const _StrategiesList = (props: StrategiesListProps) => {
                                                             </StyledTitle>
 
                                                             <StyledSubtitle>
-                                                                {' '}
                                                                 Total debt
                                                             </StyledSubtitle>
                                                         </Grid>
@@ -328,7 +332,6 @@ const _StrategiesList = (props: StrategiesListProps) => {
                                                             </StyledTitle>
 
                                                             <StyledSubtitle>
-                                                                {' '}
                                                                 Debt ratio
                                                             </StyledSubtitle>
                                                         </Grid>
@@ -356,7 +359,6 @@ const _StrategiesList = (props: StrategiesListProps) => {
                                                             md={2}
                                                         >
                                                             <StyledTitle>
-                                                                {' '}
                                                                 <DebTooltip
                                                                     label={
                                                                         vault &&
@@ -371,7 +373,6 @@ const _StrategiesList = (props: StrategiesListProps) => {
                                                             </StyledTitle>
 
                                                             <StyledSubtitle>
-                                                                {' '}
                                                                 Credit available
                                                             </StyledSubtitle>
                                                         </Grid>
@@ -399,7 +400,6 @@ const _StrategiesList = (props: StrategiesListProps) => {
                                                                 />
                                                             </StyledTitle>
                                                             <StyledSubtitle>
-                                                                {' '}
                                                                 Total Estimated
                                                                 Assets
                                                             </StyledSubtitle>

--- a/src/components/app/VaultItemList/index.tsx
+++ b/src/components/app/VaultItemList/index.tsx
@@ -66,7 +66,9 @@ const StyledReportProblem = styled(ReportProblem)`
     }
 `;
 
-const StyledMuiAccordion = styled(MuiAccordion)<{ config: string }>`
+const StyledMuiAccordion = styled(MuiAccordion).withConfig({
+    shouldForwardProp: (props) => !(props.toString() in ['config']),
+})<{ config: string }>`
     && {
         width: 100%;
         margin-top: 15px;
@@ -106,14 +108,14 @@ const _VaultItemList = (props: VaultItemListProps) => {
                 id="panel1a-header"
                 onClick={() => setExpanded(!expanded)}
             >
-                <Grid container spacing={1} justify="flex-start">
+                <Grid container spacing={1} justifyContent="flex-start">
                     <Grid item md={12} xs={12}>
                         <BlueOnGreenTooltip title="" placement="top">
                             <Grid
                                 container
                                 spacing={1}
                                 direction="row"
-                                justify="flex-start"
+                                justifyContent="flex-start"
                                 alignItems="center"
                             >
                                 <Grid item md={1} xs={3}>
@@ -170,7 +172,6 @@ const _VaultItemList = (props: VaultItemListProps) => {
                                         to={`/network/${network}/vault/${vault.address}`}
                                     >
                                         <StyledTextValue>
-                                            {' '}
                                             {vault.name}
                                             {` v${vault.apiVersion}`}
                                         </StyledTextValue>
@@ -181,7 +182,6 @@ const _VaultItemList = (props: VaultItemListProps) => {
                                     </StyledStrats>
                                 </Grid>
                                 <Hidden xsDown>
-                                    {' '}
                                     <Grid item md={6} xs={9}>
                                         <EtherScanLink
                                             address={vault.address}

--- a/src/components/common/EtherScanLink/index.tsx
+++ b/src/components/common/EtherScanLink/index.tsx
@@ -3,13 +3,13 @@ import { Link as RouterLink } from 'react-router-dom';
 import styled from 'styled-components';
 import { toChecksumAddress } from 'ethereum-checksum-address';
 
-import Button from '@material-ui/core/Button';
-import { extractAddress } from '../../../utils/commonUtils';
 import Hidden from '@material-ui/core/Hidden';
 import CallMadeIcon from '@material-ui/icons/CallMade';
 import Tooltip from '@material-ui/core/Tooltip';
 import { FileCopy } from '@material-ui/icons';
 import { Link, Grid } from '@material-ui/core';
+
+import { extractAddress } from '../../../utils/commonUtils';
 import getNetworkConfig from '../../../utils/config';
 import { Network } from '../../../types';
 
@@ -20,38 +20,48 @@ type EtherScanLinkProps = {
     internalHref?: string;
     network: Network;
 };
+
 const StyledFileCopy = styled(FileCopy)`
     && {
         color: ${({ theme }) => theme.text} !important;
-
-        border-radius: 3;
-        padding: 2;
     }
 `;
+
 const StyledCallMadeIcon = styled(CallMadeIcon)`
     && {
         color: ${({ theme }) => theme.text} !important;
-        border-radius: 3;
-        padding: 2;
     }
 `;
+
+const StyledLink = styled.a`
+    && {
+        padding: 0;
+        padding-left: 16px;
+        cursor: pointer;
+
+        :hover {
+            filter: brightness(80%);
+        }
+    }
+`;
+
 const StyledAddress = styled.span`
     && {
         color: ${({ theme }) => theme.subtitle} !important;
 
         text-decoration: none;
         font-weight: 400;
-
-        line-height: 14px;
         font-size: 16px;
         font-style: normal;
     }
 `;
+
 const StyledCopiedText = styled.span`
     && {
         color: ${({ theme }) => theme.subtitle} !important;
     }
 `;
+
 const EtherScanLink = (props: EtherScanLinkProps) => {
     const { address, transactionHash, internalHref, network } = props;
     const [copied, setCopied] = useState(false);
@@ -111,19 +121,17 @@ const EtherScanLink = (props: EtherScanLinkProps) => {
                 </StyledAddress>
 
                 <Tooltip title="Copy to clipboard" aria-label="Clipboard">
-                    <Button onClick={(e) => onCopyToClipboard(e)}>
-                        <StyledFileCopy fontSize="inherit" />
-                        {copied ? (
-                            <StyledCopiedText> Copied</StyledCopiedText>
-                        ) : (
-                            ''
-                        )}
-                    </Button>
+                    <StyledLink onClick={(e) => onCopyToClipboard(e)}>
+                        <StyledCopiedText>
+                            <StyledFileCopy fontSize="inherit" />
+                            {copied ? ' Copied' : ''}
+                        </StyledCopiedText>
+                    </StyledLink>
                 </Tooltip>
                 <Tooltip title="View on Explorer" aria-label="Explorer">
-                    <Button href={refLink} target="_blank">
+                    <StyledLink href={refLink} target="_blank">
                         <StyledCallMadeIcon fontSize="inherit" />
-                    </Button>
+                    </StyledLink>
                 </Tooltip>
             </Grid>
         </Grid>

--- a/src/components/common/HealthCheckIcon/index.tsx
+++ b/src/components/common/HealthCheckIcon/index.tsx
@@ -52,7 +52,6 @@ const HealthCheckIcon = (props: HealthCheckIconProps) => {
             title={
                 <React.Fragment>
                     <Typography color="inherit">
-                        {' '}
                         {'Health Check'}:{' '}
                         {healthCheck ? healthCheck : 'Not set'}
                         <br />

--- a/src/components/common/ItemDescription/index.tsx
+++ b/src/components/common/ItemDescription/index.tsx
@@ -64,14 +64,8 @@ const ItemDescription = (props: ItemDescriptionProps) => {
 
     return (
         <Grid item xs={xs} md={props.md} style={{ marginBottom: 50 }}>
-            <StyledTitle>
-                {' '}
-                {props.value}
-                <br />
-            </StyledTitle>
-
+            <StyledTitle>{props.value}</StyledTitle>
             <StyledSubtitle>
-                {' '}
                 {props.label}: {helpTooltip}
             </StyledSubtitle>
         </Grid>

--- a/src/components/common/ProgressSpinnerBar/ProgressSpinnerBar.tsx
+++ b/src/components/common/ProgressSpinnerBar/ProgressSpinnerBar.tsx
@@ -10,10 +10,12 @@ const StyledTypography = styled(Typography)`
     font-weight: 200;
     color: white;
 `;
+
 const StyledRootDiv = styled.div`
     width: 100%;
-    margin-top: 2;
+    margin: 16px auto;
 `;
+
 const StyledLinearProgress = styled(LinearProgress)`
     && {
         .MuiLinearProgress-bar {

--- a/src/components/common/ProtocolsList/index.tsx
+++ b/src/components/common/ProtocolsList/index.tsx
@@ -133,7 +133,7 @@ export const ProtocolsList = (props: ProtocolsListProps) => {
                                             container
                                             spacing={1}
                                             direction="row"
-                                            justify="center"
+                                            justifyContent="center"
                                             alignItems="center"
                                         >
                                             {`#${

--- a/src/components/common/ScoreRowCollapse/index.tsx
+++ b/src/components/common/ScoreRowCollapse/index.tsx
@@ -63,12 +63,10 @@ export const ScoreRowCollapse = (props: ScoreRowCollapseProps) => {
                     <TableCell>
                         {'Longevity Score:'}
                         <MediaQuery query="(max-device-width: 1224px)">
-                            <br />
                             {longevityValue}
-                        </MediaQuery>{' '}
+                        </MediaQuery>
                     </TableCell>
                     <MediaQuery query="(min-device-width: 1224px)">
-                        {' '}
                         <TableCell>{longevityValue}</TableCell>
                     </MediaQuery>
                 </TableRow>
@@ -88,7 +86,7 @@ export const ScoreRowCollapse = (props: ScoreRowCollapseProps) => {
     return (
         <Grid container className={classes.root} spacing={1}>
             <Grid item xs={12}>
-                <Grid container justify="center" spacing={1}>
+                <Grid container justifyContent="center" spacing={1}>
                     <Grid key={`${index}-1`} item xs={8}>
                         <Paper className={classes.paper}>
                             <CardContent data={data} />

--- a/src/components/common/SearchInput/index.tsx
+++ b/src/components/common/SearchInput/index.tsx
@@ -74,6 +74,7 @@ const StyledFormControlLabel = styled(FormControlLabel)`
 `;
 const StyledSelect = styled(Select)`
     && {
+        color: ${({ theme }) => theme.text} !important;
         margin-left: 44px;
         margin-top: 2px;
         margin-bottom: 2px;

--- a/src/components/common/TokenPrice/index.tsx
+++ b/src/components/common/TokenPrice/index.tsx
@@ -21,7 +21,9 @@ const useStyles = makeStyles({
     },
 });
 
-const StyledTableRow = styled(TableRow)<{ bckDark?: string }>`
+const StyledTableRow = styled(TableRow).withConfig({
+    shouldForwardProp: (props) => !(props.toString() in ['bckDark']),
+})<{ bckDark?: string }>`
     && {
         background-color: ${({ theme, bckDark }) =>
             bckDark == 'true' ? theme.body : theme.container} !important;
@@ -109,27 +111,25 @@ const TokenPrice = (props: TokenPriceProps) => {
     );
 
     return (
-        <StyledTableRow bckDark={props.bckDark === 'true' ? 'true' : 'false'}>
+        <StyledTableRow bckDark={props.bckDark ? 'true' : 'false'}>
             <StyledTableCell>
                 <SubTitle> {label}</SubTitle>
                 <MediaQuery query="(max-device-width: 1224px)">
-                    {' '}
                     <br />
                     <LabelTypography>
                         {tokenPrice
                             ? displayAmount(tokenPrice?.toFixed(2), 0)
-                            : '-'}{' '}
+                            : '-'}
                         USD
                     </LabelTypography>
-                </MediaQuery>{' '}
+                </MediaQuery>
             </StyledTableCell>
             <MediaQuery query="(min-device-width: 1224px)">
                 <StyledTableCell>
                     <LabelTypography>
-                        {' '}
                         {tokenPrice
                             ? `${displayAmount(tokenPrice?.toFixed(2), 0)} USD`
-                            : '-'}{' '}
+                            : '-'}
                     </LabelTypography>
                     {tooltip}
                 </StyledTableCell>

--- a/src/components/common/VaultsList/index.tsx
+++ b/src/components/common/VaultsList/index.tsx
@@ -1,10 +1,8 @@
 import { useState, useEffect, useCallback, useMemo, memo } from 'react';
 import { Link as RouterLink } from 'react-router-dom';
-import { makeStyles, Theme, createStyles } from '@material-ui/core/styles';
 import styled from 'styled-components';
 import sum from 'lodash/sum';
 import Button from '@material-ui/core/Button';
-import { Typography } from '@material-ui/core';
 
 import ProgressSpinnerBar from '../../common/ProgressSpinnerBar/ProgressSpinnerBar';
 
@@ -13,23 +11,24 @@ import SearchInput, { Flags } from '../SearchInput';
 import { VaultItemList } from '../../app';
 import { EMPTY_ADDRESS } from '../../../utils/commonUtils';
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const useStyles = makeStyles((theme: Theme) =>
-    createStyles({
-        text: {
-            color: '#eb0009',
-            fontWeight: 'bolder',
-            letterSpacing: '0.1em',
-        },
-    })
-);
-const StyledContainer = styled.div`
+const StyledReportContainer = styled.div`
     && {
         display: flex;
         justify-content: center;
-        margin-top: 8px;
+        margin: 16px auto;
+        background: ${({ theme }) => theme.container};
+        border: 1px solid ${({ theme }) => theme.secondary};
+        max-width: fit-content;
+        border-radius: 8px;
     }
 `;
+
+const StyledReportTitle = styled.div`
+    && {
+        color: ${({ theme }) => theme.title};
+    }
+`;
+
 type VaultsListProps = {
     items: Vault[];
     totalItems: number;
@@ -41,7 +40,6 @@ const getTotalStrategies = (items: Vault[]): number =>
 
 const _VaultsList = (props: VaultsListProps) => {
     const { totalItems, items, network } = props;
-    const classes = useStyles();
     const [filteredItems, setFilteredItems] = useState(items);
     const totalStrategies = useMemo(() => getTotalStrategies(items), [items]);
     const [totalStrategiesFound, setTotalStrategiesFound] =
@@ -163,9 +161,9 @@ const _VaultsList = (props: VaultsListProps) => {
             />
 
             {stillLoading && (
-                <ProgressSpinnerBar label={`total Vaults ${totalItems}...`} />
+                <ProgressSpinnerBar label={`Total Vaults ${totalItems}...`} />
             )}
-            <div style={{ height: '60vh', overflow: 'scroll' }}>
+            <div style={{ height: '60vh', overflow: 'auto' }}>
                 {filteredItems.map((vault: Vault, index: number) => (
                     <div key={index}>
                         <VaultItemList
@@ -176,14 +174,14 @@ const _VaultsList = (props: VaultsListProps) => {
                     </div>
                 ))}
             </div>
-            <StyledContainer>
+            <StyledReportContainer>
                 <Button
                     component={RouterLink}
                     to={`/network/${network}/report`}
                 >
-                    <Typography className={classes.text}>Report</Typography>
+                    <StyledReportTitle>HealthCheck Report</StyledReportTitle>
                 </Button>
-            </StyledContainer>
+            </StyledReportContainer>
         </>
     );
 };

--- a/src/components/theme/globalStyles.js
+++ b/src/components/theme/globalStyles.js
@@ -2,34 +2,35 @@ import { createGlobalStyle } from 'styled-components';
 
 export const GlobalStyles = createGlobalStyle`
   body {
-
-      background-image: ${({ theme }) => theme.backgroundImage};
-      background-repeat: no-repeat; 
-      background-position: center;
-     
-      -moz-background-size: cover;
-      -o-background-size: cover;
-      background-size: cover;
-      height:100%;
-      width:100%; 
-      color: ${({ theme }) => theme.text};
-      font-family: 'Roboto', sans-serif;
-     background-attachment: fixed; 
-  
-     
+    margin: 16px 0;
+    background-image: ${({ theme }) => theme.backgroundImage};
+    background-repeat: no-repeat; 
+    background-position: center;
+    
+    -moz-background-size: cover;
+    -o-background-size: cover;
+    background-size: cover;
+    height:100%;
+    width:100%; 
+    color: ${({ theme }) => theme.text};
+    font-family: 'Roboto', sans-serif;
+    background-attachment: fixed; 
   }
-  `;
+
+  * {
+    box-sizing: border-box;
+  }
+`;
 
 export const GlobalStylesLoading = createGlobalStyle`
   body {
-       
-        background-image: ${({ theme }) => theme.backgroundImageLoading};
-        background-repeat: no-repeat;
-        background-position: center center;
-        background-attachment: fixed;
-        background-size: cover;
+    box-sizing: border-box;
+    background-image: ${({ theme }) => theme.backgroundImageLoading};
+    background-repeat: no-repeat;
+    background-position: center center;
+    background-attachment: fixed;
+    background-size: cover;
 
-        color: ${({ theme }) => theme.text};
- 
+    color: ${({ theme }) => theme.text};
   }
-  `;
+`;


### PR DESCRIPTION
- Cleaned up horizontal scroll bars appearing unnecessarily 
- Improved spacing / text color on a few elements to make things easier to read
- Deleted/cleaned up a bunch of extra whitespace and other prop errors that were causing the console to log errors on page load
- Fix extra `%` on gen lender tab