### PR TITLE
fix: arbitrum risk page not loading

### DIFF
--- a/src/utils/config/risk-framework.json
+++ b/src/utils/config/risk-framework.json
@@ -777,6 +777,28 @@
             "protocolSafetyScore": 5,
             "complexityScore": 5,
             "teamKnowledgeScore": 5
+        },
+        {
+            "id": "curve",
+            "network": "arbitrum",
+            "label": "Curve",
+            "codeReviewScore": 4,
+            "testingScore": 3,
+            "auditScore": 2,
+            "protocolSafetyScore": 1,
+            "complexityScore": 2,
+            "teamKnowledgeScore": 1,
+            "criteria": {
+                "nameLike": [
+                    "crv",
+                    "curve"
+                ],
+                "strategies": [],
+                "exclude": [
+                    "singlesided",
+                    "convex"
+                ]
+            }
         }
     ]
 }

--- a/src/utils/config/risk-framework.json
+++ b/src/utils/config/risk-framework.json
@@ -799,6 +799,24 @@
                     "convex"
                 ]
             }
+        },
+        {
+            "id": "others",
+            "network": "arbitrum",
+            "label": "Others",
+            "criteria": {
+                "nameLike": [],
+                "strategies": [],
+                "exclude": [
+                   
+                ]
+            },
+            "codeReviewScore": 5,
+            "testingScore": 5,
+            "auditScore": 5,
+            "protocolSafetyScore": 5,
+            "complexityScore": 5,
+            "teamKnowledgeScore": 5
         }
     ]
 }


### PR DESCRIPTION
https://github.com/yearn/yearn-watch/issues/244

I added a json entry for arbitrum. there was only one vault/strategy on arbitrum and it was for curve so I just copy pasted the curve entry from the ethereum section. Feel free to tell me to change.