### PR TITLE
fix: load others group in fantom

### DIFF
--- a/src/utils/config/risk-framework.json
+++ b/src/utils/config/risk-framework.json
@@ -773,7 +773,7 @@
             "network": "fantom",
             "label": "Others",
             "criteria": {
-                "nameLike": [],
+                "nameLike": ["all"],
                 "strategies": [],
                 "exclude": [
                     "StrategyLenderYieldOptimiser",


### PR DESCRIPTION
Suggested fix for #250 

I have added the "all" keyword to the `risk-framework.json` file assuming that we want the same functionality as in the Ethereum network.
It is the first time opening a PR here and I am new to the codebase, please let me know if I missed something :)