### PR TITLE
Fix/sdk 1.2.0 single vault query

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
         "@types/react-responsive": "^8.0.2",
         "@types/react-router-dom": "^5.1.7",
         "@typesaurus/react": "^4.0.1",
-        "@yfi/sdk": "1.0.25",
+        "@yfi/sdk": "1.2.0",
         "axios": "^0.21.1",
         "bignumber.js": "^9.0.1",
         "compare-versions": "^3.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3295,9 +3295,10 @@
   resolved "https://registry.yarnpkg.com/@xtuc/long/-/long-4.2.2.tgz#d291c6a4e97989b5c61d9acf396ae4fe133a718d"
   integrity sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==
 
-"@yfi/sdk@1.0.25":
-  version "1.0.25"
-  resolved "https://registry.yarnpkg.com/@yfi/sdk/-/sdk-1.0.25.tgz#4241b80bf3ce9690bb23c8492b279ded7a248f5b"
+"@yfi/sdk@1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@yfi/sdk/-/sdk-1.2.0.tgz#b0635ced261cab41c57272ebb00ea7041702d74b"
+  integrity sha512-o0GE+enTlUDwuP+W7TD7/5r5s2xuMTj93vPpUmDYePOunx3B85jwEl2FLUugTOdsku8eKhLLhLJTx6fJmSJLAw==
   dependencies:
     bignumber.js "9.0.1"
     cross-fetch "3.1.4"


### PR DESCRIPTION
this fixes individual vaults not being rendered at all:
https://yearn.watch/network/ethereum/vault/0x9d409a0A012CFbA9B15F6D4B36Ac57A46966Ab9a

It should also improve the overall rendering performance of the vault's detail view because now only a single vault will be requested from the sdk instead of all vaults.