### PR TITLE
fix: return 0 for longevity if activation is zero

### DIFF
--- a/src/types/protocol-tvl.ts
+++ b/src/types/protocol-tvl.ts
@@ -10,6 +10,9 @@ export class ProtocolTVL {
     ) {}
 
     getLongevityDays(): number {
+        if (this.activation === 0) {
+            return 0;
+        }
         const diffMs = Date.now() - this.activation;
         const diffDays = diffMs / 1000 / 60 / 60 / 24;
         return diffDays;

--- a/src/types/protocol-tvl.ts
+++ b/src/types/protocol-tvl.ts
@@ -1,5 +1,6 @@
 import BigNumber from 'bignumber.js';
 import { StrategyTVL } from './strategy-tvl';
+import { isValidTimestamp } from '../utils/dateUtils';
 
 export class ProtocolTVL {
     constructor(
@@ -10,12 +11,12 @@ export class ProtocolTVL {
     ) {}
 
     getLongevityDays(): number {
-        if (this.activation === 0) {
-            return 0;
+        if (this.activation && isValidTimestamp(this.activation.toString())) {
+            const diffMs = Date.now() - this.activation;
+            const diffDays = diffMs / 1000 / 60 / 60 / 24;
+            return diffDays;
         }
-        const diffMs = Date.now() - this.activation;
-        const diffDays = diffMs / 1000 / 60 / 60 / 24;
-        return diffDays;
+        return 0;
     }
 
     hasName(name: string): boolean {


### PR DESCRIPTION
Suggestion for #150

I assumed that the default activation for ProtocolTVL will stay as zero