### PR TITLE
feat: add ENS resolver

### DIFF
--- a/src/components/app/SingleVault/VaultDescription.tsx
+++ b/src/components/app/SingleVault/VaultDescription.tsx
@@ -14,6 +14,7 @@ import ProgressBars from '../../common/ProgressBar';
 import { Network, Vault } from '../../../types';
 import { LabelTypography, SubTitle } from '../../common/Labels';
 import getNetworkConfig from '../../../utils/config';
+import EtherScanLink from '../../common/EtherScanLink';
 
 interface VaultDescriptionProps {
     vault: Vault | undefined;
@@ -74,18 +75,38 @@ export const VaultDescription = (props: VaultDescriptionProps) => {
                 }}
             />
         );
-    const rewards = vault
-        ? networkConfig.treasury.getEnsOrAddress(vault.rewards)
-        : '';
-    const governance = vault
-        ? networkConfig.governance.getEnsOrAddress(vault.governance)
-        : '';
-    const management = vault
-        ? networkConfig.management.getEnsOrAddress(vault.management)
-        : '';
-    const guardian = vault
-        ? networkConfig.guardian.getEnsOrAddress(vault.guardian)
-        : '';
+    const rewards = vault ? (
+        <EtherScanLink
+            address={networkConfig.treasury.getEnsOrAddress(vault.rewards)}
+            network={network}
+        />
+    ) : (
+        ''
+    );
+    const governance = vault ? (
+        <EtherScanLink
+            address={networkConfig.governance.getEnsOrAddress(vault.governance)}
+            network={network}
+        />
+    ) : (
+        ''
+    );
+    const management = vault ? (
+        <EtherScanLink
+            address={networkConfig.management.getEnsOrAddress(vault.management)}
+            network={network}
+        />
+    ) : (
+        ''
+    );
+    const guardian = vault ? (
+        <EtherScanLink
+            address={networkConfig.guardian.getEnsOrAddress(vault.guardian)}
+            network={network}
+        />
+    ) : (
+        ''
+    );
     const total_asset =
         vault &&
         displayAmount(vault.totalAssets, vault.token.decimals) +

--- a/src/components/common/EtherScanLink/index.tsx
+++ b/src/components/common/EtherScanLink/index.tsx
@@ -69,10 +69,7 @@ const EtherScanLink = (props: EtherScanLinkProps) => {
     const [value, setValue] = useState('');
     const [extractedValue, setExtractedValue] = useState('');
     const [hashValue, setHashValue] = useState('');
-<<<<<<< HEAD
     const [resolved, setResolved] = useState(false);
-=======
->>>>>>> feat: add ENS resolver
     const networkConfig = getNetworkConfig(network);
 
     useEffect(() => {
@@ -90,7 +87,6 @@ const EtherScanLink = (props: EtherScanLinkProps) => {
                 setValue(address);
                 setExtractedValue(address);
                 const provider = getEthersDefaultProvider(network);
-<<<<<<< HEAD
                 provider
                     .resolveName(address)
                     .then((res) => {
@@ -111,26 +107,13 @@ const EtherScanLink = (props: EtherScanLinkProps) => {
                     setExtractedValue(address);
                     setResolved(false);
                 }
-=======
-                provider.resolveName(address).then((res) => {
-                    setHashValue(res || '');
-                });
-            } else {
-                const checksumAddress = toChecksumAddress(address);
-                setValue(checksumAddress);
-                setExtractedValue(extractAddress(address));
-                setHashValue(checksumAddress);
->>>>>>> feat: add ENS resolver
             }
         }
         if (transactionHash) {
             setValue(transactionHash);
             setExtractedValue(extractAddress(transactionHash));
             setHashValue(transactionHash);
-<<<<<<< HEAD
             setResolved(true);
-=======
->>>>>>> feat: add ENS resolver
         }
     }, []);
 
@@ -147,7 +130,6 @@ const EtherScanLink = (props: EtherScanLinkProps) => {
     const refLink = transactionHash
         ? networkConfig.toTxExplorerUrl(hashValue)
         : networkConfig.toAddressExplorerUrl(hashValue);
-<<<<<<< HEAD
 
     if (!resolved) {
         return <>{value}</>;
@@ -186,42 +168,6 @@ const EtherScanLink = (props: EtherScanLinkProps) => {
                         </StyledLink>
                     </Tooltip>
                 </Grid>
-=======
-    return (
-        <Grid container spacing={2} alignItems="center">
-            <Grid item>
-                <StyledAddress>
-                    {internalHref ? (
-                        <Link
-                            component={RouterLink}
-                            color="inherit"
-                            to={internalHref}
-                        >
-                            <Hidden smUp>{maskedValue}</Hidden>
-                            <Hidden smDown>{value}</Hidden>
-                        </Link>
-                    ) : (
-                        <>
-                            <Hidden smUp>{maskedValue}</Hidden>
-                            <Hidden smDown>{value}</Hidden>
-                        </>
-                    )}
-                </StyledAddress>
-
-                <Tooltip title="Copy to clipboard" aria-label="Clipboard">
-                    <StyledLink onClick={(e) => onCopyToClipboard(e)}>
-                        <StyledCopiedText>
-                            <StyledFileCopy fontSize="inherit" />
-                            {copied ? ' Copied' : ''}
-                        </StyledCopiedText>
-                    </StyledLink>
-                </Tooltip>
-                <Tooltip title="View on Explorer" aria-label="Explorer">
-                    <StyledLink href={refLink} target="_blank">
-                        <StyledCallMadeIcon fontSize="inherit" />
-                    </StyledLink>
-                </Tooltip>
->>>>>>> feat: add ENS resolver
             </Grid>
         );
     }

--- a/src/components/common/EtherScanLink/index.tsx
+++ b/src/components/common/EtherScanLink/index.tsx
@@ -69,7 +69,10 @@ const EtherScanLink = (props: EtherScanLinkProps) => {
     const [value, setValue] = useState('');
     const [extractedValue, setExtractedValue] = useState('');
     const [hashValue, setHashValue] = useState('');
+<<<<<<< HEAD
     const [resolved, setResolved] = useState(false);
+=======
+>>>>>>> feat: add ENS resolver
     const networkConfig = getNetworkConfig(network);
 
     useEffect(() => {
@@ -87,6 +90,7 @@ const EtherScanLink = (props: EtherScanLinkProps) => {
                 setValue(address);
                 setExtractedValue(address);
                 const provider = getEthersDefaultProvider(network);
+<<<<<<< HEAD
                 provider
                     .resolveName(address)
                     .then((res) => {
@@ -107,13 +111,26 @@ const EtherScanLink = (props: EtherScanLinkProps) => {
                     setExtractedValue(address);
                     setResolved(false);
                 }
+=======
+                provider.resolveName(address).then((res) => {
+                    setHashValue(res || '');
+                });
+            } else {
+                const checksumAddress = toChecksumAddress(address);
+                setValue(checksumAddress);
+                setExtractedValue(extractAddress(address));
+                setHashValue(checksumAddress);
+>>>>>>> feat: add ENS resolver
             }
         }
         if (transactionHash) {
             setValue(transactionHash);
             setExtractedValue(extractAddress(transactionHash));
             setHashValue(transactionHash);
+<<<<<<< HEAD
             setResolved(true);
+=======
+>>>>>>> feat: add ENS resolver
         }
     }, []);
 
@@ -130,6 +147,7 @@ const EtherScanLink = (props: EtherScanLinkProps) => {
     const refLink = transactionHash
         ? networkConfig.toTxExplorerUrl(hashValue)
         : networkConfig.toAddressExplorerUrl(hashValue);
+<<<<<<< HEAD
 
     if (!resolved) {
         return <>{value}</>;
@@ -168,6 +186,42 @@ const EtherScanLink = (props: EtherScanLinkProps) => {
                         </StyledLink>
                     </Tooltip>
                 </Grid>
+=======
+    return (
+        <Grid container spacing={2} alignItems="center">
+            <Grid item>
+                <StyledAddress>
+                    {internalHref ? (
+                        <Link
+                            component={RouterLink}
+                            color="inherit"
+                            to={internalHref}
+                        >
+                            <Hidden smUp>{maskedValue}</Hidden>
+                            <Hidden smDown>{value}</Hidden>
+                        </Link>
+                    ) : (
+                        <>
+                            <Hidden smUp>{maskedValue}</Hidden>
+                            <Hidden smDown>{value}</Hidden>
+                        </>
+                    )}
+                </StyledAddress>
+
+                <Tooltip title="Copy to clipboard" aria-label="Clipboard">
+                    <StyledLink onClick={(e) => onCopyToClipboard(e)}>
+                        <StyledCopiedText>
+                            <StyledFileCopy fontSize="inherit" />
+                            {copied ? ' Copied' : ''}
+                        </StyledCopiedText>
+                    </StyledLink>
+                </Tooltip>
+                <Tooltip title="View on Explorer" aria-label="Explorer">
+                    <StyledLink href={refLink} target="_blank">
+                        <StyledCallMadeIcon fontSize="inherit" />
+                    </StyledLink>
+                </Tooltip>
+>>>>>>> feat: add ENS resolver
             </Grid>
         );
     }


### PR DESCRIPTION
Suggestion for #239

moved some variables as component states, and created a new variable called `hashValue` to store the value for the `refLink`.
If we opt for showing the checksum hash instead of the ENS we could just toss this variable and stick with `value` hehe

![image](https://user-images.githubusercontent.com/30872891/158709290-aca94434-bbd0-4f71-afa0-595ba6a2c937.png)
I have tested using `ethereum.eth` as input, which creates a refLink to [0xde0B295669a9FD93d5F28D9Ec85E40f4cb697BAe](https://etherscan.io/address/0xde0B295669a9FD93d5F28D9Ec85E40f4cb697BAe).