### PR TITLE
fix: temporarily fetch strategies from the vault sdk for fantom

### DIFF
--- a/src/utils/config/risk-framework.json
+++ b/src/utils/config/risk-framework.json
@@ -801,8 +801,8 @@
                     "vedao",
                     "0xdao",
                     "solidexjoint",
-                    "singleassetsolidexLP",
-                    "singleassetsolidexLPwitharb"
+                    "veLp_Solidex",
+                    "veLp_arb_Solidex"
                 ]
             },
             "codeReviewScore": 5,

--- a/src/utils/strategiesHelper.ts
+++ b/src/utils/strategiesHelper.ts
@@ -6,7 +6,7 @@ import { StrategyTVL } from '../types/strategy-tvl';
 import { getAllStrategies, getStrategies } from './strategies';
 import { flattenArrays } from './commonUtils';
 import { isAddress } from 'ethers/lib/utils';
-import _, { filter } from 'lodash';
+import _ from 'lodash';
 import { getStrategiesHelperInstance } from './contracts/instances';
 import { getEthersDefaultProvider } from './ethers';
 import { Contract } from 'ethers';


### PR DESCRIPTION
temp fix for #254 #263 

I have hard-coded the patch only for the fantom network, hopefully would not interfere with the others.
Also found that there was a mismatch of names in the `risk-framework.json` file, thus changed accordingly.