### PR TITLE
Remove Duplicated Geist Lending Borrower & Fix Typo

### DIFF
--- a/src/utils/config/risk-framework.json
+++ b/src/utils/config/risk-framework.json
@@ -689,22 +689,6 @@
             }
         },
         {
-            "id": "GeistLendingBorrower",
-            "network": "fantom",
-            "label": "Geist Lending Borrower",
-            "codeReviewScore": 2,
-            "testingScore": 2,
-            "auditScore": 5,
-            "protocolSafetyScore": 3,
-            "complexityScore": 4,
-            "teamKnowledgeScore": 2,
-            "criteria": {
-                "nameLike": ["GeistLendingBorrower"],
-                "strategies": [],
-                "exclude": []
-            }
-        },
-        {
             "id": "vedao",
             "network": "fantom",
             "label": "ve DAO",
@@ -827,7 +811,7 @@
             "complexityScore": 4,
             "teamKnowledgeScore": 2,
             "criteria": {
-                "nameLike": ["GeistMIMLender", "GeistDAILender", "GeistfUSDTLender", "GeistfUSDCLender"],
+                "nameLike": ["GeistMIMLender", "GeistDAILender", "GeistfUSDTLender", "GeistUSDCLender"],
                 "strategies": [],
                 "exclude": []
             }
@@ -899,7 +883,6 @@
                     "SingleSidedBeethoven",
                     "ssbeetV2",
                     "ssbeetV2.1",
-                    "GeistLendingBorrower",
                     "vedao",
                     "0xdao",
                     "solidexjoint",
@@ -912,7 +895,7 @@
                     "GeistMIMLender",
                     "GeistDAILender",
                     "GeistfUSDTLender",
-                    "GeistfUSDCLender",
+                    "GeistUSDCLender",
                     "kashi lender"
                 ]
             },


### PR DESCRIPTION
- Remove Duplicated Geist Lending Borrower
- Fix Typo: GeistfUSDCLender -> GeistUSDCLender